### PR TITLE
Upgrade to supabase js v2

### DIFF
--- a/components/LoginForm.js
+++ b/components/LoginForm.js
@@ -38,14 +38,14 @@ export default function Login({ signup }) {
         })
     } else {
       supabase.auth
-        .signIn({
+        .signInWithPassword({
           email,
           password,
         })
-        .then(({ user, session, error }) => {
+        .then(({ data, error }) => {
           setIsSubmitting(false)
-          setErrors(error)
-          if (user) {
+          if (error) setErrors(error)
+          if (data) {
             router.push('/app/profile')
           }
         })

--- a/components/LoginForm.js
+++ b/components/LoginForm.js
@@ -13,7 +13,7 @@ export default function Login({ signup }) {
   const [sentConfirmationEmail, setSentConfirmationEmail] = useState()
 
   const router = useRouter()
-  const { user, profile } = useGlobalState()
+  const { user, profile, signOut } = useGlobalState()
 
   // const [isSignup, setIsSignup] = useState(signup)
 
@@ -74,7 +74,7 @@ export default function Login({ signup }) {
             <a
               className="link"
               onClick={() => {
-                supabase.auth.signOut()
+                signOut(`/login`)
               }}
             >
               Log out and log in as someone new

--- a/components/SetNewEmailForm.js
+++ b/components/SetNewEmailForm.js
@@ -16,8 +16,8 @@ export default function SetNewEmailForm() {
 
     const email = event.target.email.value
 
-    supabase.auth.update({ email }).then(({ user, error }) => {
-      console.log(user, error)
+    supabase.auth.update({ email }).then(({ data, error }) => {
+      console.log(data, error)
       setIsSubmitting(false)
       setSuccessfulSubmit(!error)
       setErrors(error)

--- a/components/Sidebar.js
+++ b/components/Sidebar.js
@@ -100,7 +100,7 @@ export default function Sidebar() {
               </div>
             ))}
             <p>
-              <button className="btn btn-quiet" onClick={signOut}>
+              <button className="btn btn-quiet" onClick={() => signOut(`/`)}>
                 Sign out
               </button>
             </p>

--- a/lib/global-store.js
+++ b/lib/global-store.js
@@ -9,14 +9,18 @@ import { prependAndDedupe } from './data-helpers'
   and https://ruanmartinelli.com/posts/supabase-authentication-react
 */
 
-const GlobalStateContext = createContext({})
-
 const blankProfile = {
+  user: null,
   profile: null,
+  profileError: null,
   decks: null,
+  isLoading: true,
 }
 
+const GlobalStateContext = createContext(blankProfile)
+
 const profileContextObject = profileResponseData => {
+  console.log('convert profileResponse to context { profile, decks }')
   // a successful profile response!
   // extract decks to its own top-level item
   // and calculate the publicURL of the avatar
@@ -35,90 +39,108 @@ const profileContextObject = profileResponseData => {
 
 export function GlobalStateProvider({ children }) {
   const [user, setUser] = useState()
-  const [loadingProfile, setLoadingProfile] = useState(true)
+  const [loadingUser, setLoadingUser] = useState(true)
+  const [loadingProfile, setLoadingProfile] = useState(false)
   const [profileResponse, setProfileResponse] = useState()
   const [profileError, setProfileError] = useState()
   const [loadedCards, setLoadedCards] = useState()
+
   const router = useRouter()
 
   useEffect(() => {
-    const session = supabase.auth.session()
-    setUser(session?.user ?? null)
+    if (loadingUser)
+      supabase.auth.getSession().then(({ data: { session } }) => {
+        console.log('useEffect 1: resolved getSession', session)
+        setUser(session?.user ?? null)
+        setLoadingUser(false)
+        setLoadingProfile(true)
+        return
+      })
 
     const { data: listener } = supabase.auth.onAuthStateChange(
       async (event, session) => {
-        setUser(session?.user ?? null)
-        setLoadingProfile(false)
+        // handles a logout event
+        console.log(`Supabase auth event:`, event)
+        // 'SIGNED_IN', 'SIGNED_OUT', 'TOKEN_REFRESHED', 'USER_UPDATED', 'PASSWORD_RECOVERY'
+        if (event === 'SIGNED_OUT') {
+          setUser(null)
+          setProfileError(null)
+          setProfileResponse(null)
+        }
+        if (event === 'SIGNED_IN') {
+          setUser(session.user)
+          setLoadingProfile(true)
+        }
       }
     )
 
-    if (!user) {
-      setProfileResponse(null)
-      setLoadingProfile(false)
-    } else {
-      // user and session are present so we will run the async query
-      supabase
-        .from('profile')
-        .select(`*, decks:user_deck(id, lang)`)
-        .eq('uid', user.id)
-        .single()
-        .then(({ data, error }) => {
-          if (error) {
-            setProfileError(error)
-          } else {
-            setProfileResponse(data)
-            // if there is a user but no profile this means they've missed
-            // the starting screen and need to find their way back
-            if (!data || data === [] || data === {})
-              router.push('/app/profile/start')
-          }
-          console.log('end of .then', data, error)
-          setLoadingProfile(false)
-        })
-    }
-    console.log(
-      'end of useEffect for loading Profile,',
-      `session is ${!session ? 'not ' : ''}here`
-    )
     return () => {
-      listener?.unsubscribe()
+      listener.subscription
+    }
+  }, [])
+
+  useEffect(() => {
+    if (!user?.id) {
+      setProfileResponse(null)
+      setLoadingProfile(loadingUser || false)
+    } else {
+      // user is done loading so we will run the async query
+      console.log(`useEffect 2: fetching profileData`)
+      if (loadingProfile)
+        supabase
+          .from('profile')
+          .select(`*, decks:user_deck(id, lang)`)
+          .eq('uid', user.id)
+          .maybeSingle()
+          .then(({ data, error }) => {
+            if (error) {
+              setProfileError(error)
+            } else {
+              setProfileResponse(data)
+              // if there is a user but no profile this means they've missed
+              // the starting screen and need to find their way back
+              if (!data || data === [] || data === {})
+                router.push('/app/profile/start')
+            }
+            setLoadingProfile(false)
+          })
     }
   }, [user])
 
-  const value = useMemo(() => {
-    const { decks, profile } = profileContextObject(profileResponse)
-    console.log('useMemo')
-    return {
-      user,
-      profile,
-      decks,
-      profileError,
-      signUp: data => supabase.auth.signUp(data),
-      signIn: data => supabase.auth.signIn(data),
-      signOut: () => {
-        router.push('/')
-        supabase.auth.signOut()
-      },
-      mergeProfileData: data =>
-        setProfileResponse(prev => {
-          return { ...prev, ...data }
-        }),
-      insertDeckData: data =>
-        setProfileResponse(prev => {
-          prev.decks = prependAndDedupe(data, prev.decks)
-          return [...prev]
-        }),
-      isLoading: loadingProfile,
-      loadedCards,
-      addLoadedCard: card =>
-        setLoadedCards(prev => {
-          prev[card.id] = card
-          return { ...prev }
-        }),
-    }
-  }, [user, profileResponse, profileError, loadingProfile, loadedCards])
+  const { decks, profile } = profileResponse
+    ? profileContextObject(profileResponse)
+    : { decks: null, profile: null }
 
-  console.log('Render context provider', loadingProfile, value)
+  const value = {
+    user,
+    profile,
+    decks,
+    profileError,
+    signUp: data => supabase.auth.signUp(data),
+    signIn: data => supabase.auth.signIn(data),
+    signOut: path => {
+      supabase.auth.signOut()
+      router?.push(path ?? '/')
+    },
+    mergeProfileData: data =>
+      setProfileResponse(prev => {
+        return { ...prev, ...data }
+      }),
+    insertDeckData: data =>
+      setProfileResponse(prev => {
+        prev.decks = prependAndDedupe(data, prev.decks)
+        return [...prev]
+      }),
+    isLoading: loadingUser || loadingProfile,
+    loadedCards,
+    addLoadedCard: card =>
+      setLoadedCards(prev => {
+        prev[card.id] = card
+        return { ...prev }
+      }),
+  }
+
+  console.log(`render GlobalStateContext.Provider`)
   return (
     <GlobalStateContext.Provider value={value}>
       {value.isLoading ? null : children}

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "name": "sunlo-nextjs",
       "dependencies": {
-        "@supabase/supabase-js": "^1.29.1",
+        "@supabase/supabase-js": "^2.7.1",
         "@urql/core": "^3.1.1",
         "encoding": "^0.1.13",
         "next": "^13.1.1",
@@ -379,56 +379,57 @@
       "dev": true
     },
     "node_modules/@supabase/functions-js": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-1.3.4.tgz",
-      "integrity": "sha512-yYVgkECjv7IZEBKBI3EB5Q7R1p0FJ10g8Q9N7SWKIHUU6i6DnbEGHIMFLyQRm1hmiNWD8fL7bRVEYacmTRJhHw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.0.0.tgz",
+      "integrity": "sha512-ozb7bds2yvf5k7NM2ZzUkxvsx4S4i2eRKFSJetdTADV91T65g4gCzEs9L3LUXSrghcGIkUaon03VPzOrFredqg==",
       "dependencies": {
         "cross-fetch": "^3.1.5"
       }
     },
     "node_modules/@supabase/gotrue-js": {
-      "version": "1.24.0",
-      "resolved": "https://registry.npmjs.org/@supabase/gotrue-js/-/gotrue-js-1.24.0.tgz",
-      "integrity": "sha512-6PVv7mHCFOxLm6TSBfR7hsq/y3CMKpvzePVR+ZWtlFBTjJ2J87g2OYE9bgC61P5TNeZopUXKw93H92yz0MTALw==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@supabase/gotrue-js/-/gotrue-js-2.11.0.tgz",
+      "integrity": "sha512-yo3yExoTqpJH4YpdI5PDjZ1YLOj3wURppimfsV0ep5uxDY/lE1uOhiMCPnhy59DbFAKG7bjnhJ1L7sk+B2os3w==",
       "dependencies": {
-        "cross-fetch": "^3.0.6"
+        "cross-fetch": "^3.1.5"
       }
     },
     "node_modules/@supabase/postgrest-js": {
-      "version": "0.37.4",
-      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-0.37.4.tgz",
-      "integrity": "sha512-x+c2rk1fz9s6f1PrGxCJ0QTUgXPDI0G3ngIqD5sSiXhhCyfl8Q5V92mXl2EYtlDhkiUkjFNrOZFhXVbXOHgvDw==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-1.3.2.tgz",
+      "integrity": "sha512-/RRsBNtVnUiVp1wUFY/MGfxEGDD1+lA8cxvU3cbzRCNeo1dQfzQ3cw9ssRnp1r/DXkyjzujGQ8d1a+EJewr8dQ==",
       "dependencies": {
         "cross-fetch": "^3.1.5"
       }
     },
     "node_modules/@supabase/realtime-js": {
-      "version": "1.7.5",
-      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-1.7.5.tgz",
-      "integrity": "sha512-nXuoxt7NE1NTI+G8WBim1K2gkUC8YE3e9evBUG+t6xwd9Sq+sSOrjcE0qJ8/Y631BCnLzlhX6yhFYQFh1oQDOg==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.6.0.tgz",
+      "integrity": "sha512-tOVulMobhpxyDuu8VIImpL8FXmZOKsGNOSyS5ihJdj2xYmPPvYG+D2J51Ewfl+MFF65tweiB6p9N9bNIW1cDNA==",
       "dependencies": {
         "@types/phoenix": "^1.5.4",
         "websocket": "^1.0.34"
       }
     },
     "node_modules/@supabase/storage-js": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-1.7.3.tgz",
-      "integrity": "sha512-jnIZWqOc9TGclOozgX9v/RWGFCgJAyW/yvmauexgRZhWknUXoA4b2i8tj7vfwE0WTvNRuA5JpXID98rfJeSG7Q==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.3.0.tgz",
+      "integrity": "sha512-YGWVCEYYYF3+UiyL8O4xC78N9n9paLbT0hHl8dmYAtd3DqyWtu5Eph9JTu0PWm+/29Zhns5TbhUZW4xpWjJfPQ==",
       "dependencies": {
-        "cross-fetch": "^3.1.0"
+        "cross-fetch": "^3.1.5"
       }
     },
     "node_modules/@supabase/supabase-js": {
-      "version": "1.35.7",
-      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-1.35.7.tgz",
-      "integrity": "sha512-X+qCzmj5sH0dozagbLoK7LzysBaWoivO0gsAUAPPBQkQupQWuBfaOqG18gKhlfL0wp2PL888QzhQNScp/IwUfA==",
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.7.1.tgz",
+      "integrity": "sha512-Q/e+JAluZEvy7D4ul3aAs3aOiKkGvHlZULy6wjchWQyU9YlJKZLr6VPYcwUeitcnRKZi4al5iTS55LgdJFfqIA==",
       "dependencies": {
-        "@supabase/functions-js": "^1.3.4",
-        "@supabase/gotrue-js": "^1.22.21",
-        "@supabase/postgrest-js": "^0.37.4",
-        "@supabase/realtime-js": "^1.7.5",
-        "@supabase/storage-js": "^1.7.2"
+        "@supabase/functions-js": "^2.0.0",
+        "@supabase/gotrue-js": "^2.10.2",
+        "@supabase/postgrest-js": "^1.1.1",
+        "@supabase/realtime-js": "^2.4.0",
+        "@supabase/storage-js": "^2.1.0",
+        "cross-fetch": "^3.1.5"
       }
     },
     "node_modules/@swc/helpers": {
@@ -2986,9 +2987,9 @@
       }
     },
     "node_modules/node-gyp-build": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.5.0.tgz",
-      "integrity": "sha512-2iGbaQBV+ITgCz76ZEjmhUKAKVf7xfY1sRl4UiKQspfZMH2h06SyhNsnSVy50cwkFQDGLyif6m/6uFXHkOZ6rg==",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.6.0.tgz",
+      "integrity": "sha512-NTZVKn9IylLwUzaKjkas1e4u2DLNcV4rdYagA4PWdPwW87Bi7z+BznyKSRwS/761tV/lzCGXplWsiaMjLqP2zQ==",
       "bin": {
         "node-gyp-build": "bin.js",
         "node-gyp-build-optional": "optional.js",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@supabase/supabase-js": "^1.29.1",
+    "@supabase/supabase-js": "^2.7.1",
     "@urql/core": "^3.1.1",
     "encoding": "^0.1.13",
     "next": "^13.1.1",

--- a/pages/app/profile/index.js
+++ b/pages/app/profile/index.js
@@ -4,10 +4,7 @@ import supabase from 'lib/supabase-client'
 import AppProfileLayout from 'components/AppProfileLayout'
 import { useGlobalState } from 'lib/global-store'
 import ErrorList from 'components/ErrorList'
-import {
-  // prependAndDedupe,
-  convertNodeListToCheckedValues,
-} from 'lib/data-helpers'
+import { convertNodeListToCheckedValues } from 'lib/data-helpers'
 import languages from 'lib/languages'
 
 const ProfileCard = () => {
@@ -134,7 +131,7 @@ const UserAuthCard = () => {
           <input
             type="text"
             className="border rounded p-3 flex-grow"
-            value={user.email}
+            value={user?.email ?? 'loading...'}
             disabled
           />
           <Link href="/app/profile/change-email" className="btn btn-quiet">


### PR DESCRIPTION
The supabase client no longer provides a synchronous access to the session or session.user, so this PR re-arranges the global context provider quite a bit, separating the user and profile access into two separate useEffects and explicitly relying on two separate loading states, loading the user and only fetching the profile when the user is finished loading.

While I was here I also updated the sign-out buttons to use the signOut function in the Global Context provider, which calls `supabase.auth.signOut` but also accepts a redirect path and users `router.push` to go there.