### PR TITLE
Cleanup global store

### DIFF
--- a/lib/global-store.js
+++ b/lib/global-store.js
@@ -91,7 +91,6 @@ export function GlobalStateProvider({ children }) {
       setLoadingProfile(loadingUser || false)
     } else {
       // user is done loading so we will run the async query
-      console.log(`useEffect 2: fetching profileData`)
       if (loadingProfile)
         supabase
           .from('profile')
@@ -102,6 +101,7 @@ export function GlobalStateProvider({ children }) {
             if (error) {
               setProfileError(error)
             } else {
+              console.log(`useEffect 2: resolved profileResponse`, data)
               setProfileResponse(data)
               // if there is a user but no profile this means they've missed
               // the starting screen and need to find their way back

--- a/lib/global-store.js
+++ b/lib/global-store.js
@@ -62,13 +62,19 @@ export function GlobalStateProvider({ children }) {
         // handles a logout event
         console.log(`Supabase auth event:`, event)
         // 'SIGNED_IN', 'SIGNED_OUT', 'TOKEN_REFRESHED', 'USER_UPDATED', 'PASSWORD_RECOVERY'
+        if (event === 'USER_UPDATED') {
+          setUser(session?.user ?? null)
+        }
         if (event === 'SIGNED_OUT') {
+          setLoadingUser(false)
+          setLoadingProfile(false)
           setUser(null)
-          setProfileError(null)
           setProfileResponse(null)
+          setProfileError(null)
         }
         if (event === 'SIGNED_IN') {
-          setUser(session.user)
+          setUser(session?.user ?? null)
+          setLoadingUser(false)
           setLoadingProfile(true)
         }
       }

--- a/lib/global-store.js
+++ b/lib/global-store.js
@@ -149,7 +149,7 @@ export function GlobalStateProvider({ children }) {
   console.log(`render GlobalStateContext.Provider`)
   return (
     <GlobalStateContext.Provider value={value}>
-      {value.isLoading ? null : children}
+      {children}
     </GlobalStateContext.Provider>
   )
 }


### PR DESCRIPTION
This is the final cleanup step for the time being, connected with #8 . This PR sort of polishes off the recent refactoring to global-store. 

In recent work we separated setUser and setProfileResponse into two separate useEffects and async actions, and created clear loading and states for each. 

In this PR we rearrange a bit of the `console.log` statements to be less noisy while still showing what's needed to ensure we're not rendering and fetching too much. And we make more clear what exactly to do with different AuthState changes from the supabase client listener.

Now that I feel more confident about loading and handling of incomplete data, I also simplified the render to just

```jsx
  return (
    <GlobalStateContext.Provider value={value}>
      {children}
    </GlobalStateContext.Provider>
  )
```
There used to be a `{value.isLoading ? null : children}` to ensure we weren't trying to render with incomplete data, but the app should handle this gracefully enough now, so I removed the check. It's snappier now! but I'll have to start adding "loading" state components to really see the benefit (which I probably don't feel like doing).