### PR TITLE
Change some styles, "no cards" page, remove dead code

### DIFF
--- a/app/(app)/layout.js
+++ b/app/(app)/layout.js
@@ -2,7 +2,7 @@ import Sidebar from 'app/components/Sidebar'
 
 export default function Layout({ children }) {
   return (
-    <div className="md:flex flex-row gap-6 bg-primary text-white min-h-screen">
+    <div className="md:flex flex-row bg-primary text-white min-h-screen">
       <Sidebar shy={true} />
       <div className="flex-grow py-6 px-min min-h-60vh">
         <div className="container">{children}</div>

--- a/app/(app)/my-decks/ClientPage.tsx
+++ b/app/(app)/my-decks/ClientPage.tsx
@@ -10,7 +10,7 @@ function OneDeck({ node }) {
   return (
     <Link
       href={`/my-decks/${node.lang}`}
-      className="card w-100 shadow-lg p-6 my-4 hover:bg-purple-200"
+      className="card w-100 shadow-lg p-6 my-4 hover:bg-primary/20"
     >
       <h2 className="h2">{languages[node.lang]}</h2>
       <p>

--- a/app/(app)/my-decks/[lang]/Browse.js
+++ b/app/(app)/my-decks/[lang]/Browse.js
@@ -15,7 +15,9 @@ export default function Browse({ lang, disable }) {
   if (status === 'error') return <ErrorList error={error} />
   if (!data?.length) {
     return (
-      <>there are no phrases for this language 💩 you'll need to add some.</>
+      <p className="bg-primary/10 p-6 rounded-lg">
+        there are no phrases for this language 💩 you'll need to add some.
+      </p>
     )
   }
 

--- a/app/(app)/my-decks/[lang]/ClientPage.js
+++ b/app/(app)/my-decks/[lang]/ClientPage.js
@@ -6,6 +6,7 @@ import { useDeck } from 'app/data/hooks'
 import { useState } from 'react'
 import Card from 'app/components/Card'
 import Browse from './Browse'
+import Garlic from 'app/components/Garlic'
 
 const Empty = () => <p className="text-gray-600">No cards here</p>
 
@@ -20,7 +21,17 @@ export default function ClientPage({ lang }) {
   if (!edges?.length)
     return (
       <div>
-        no cards in deck 💩 go ahead and add some! <Browse lang={lang} />
+        <div className="flex flex-row">
+          <Garlic className="mx-4" />
+          <h2 className="h2">It looks like this is a brand new deck!</h2>
+        </div>
+
+        <p className="my-4">
+          You can get started by browsing the phrases we already have in the
+          library and adding cards to your deck, or create your own!
+        </p>
+
+        <Browse lang={lang} />
       </div>
     )
   // a simple array ['a12...', '45f...', ... ]

--- a/app/(app)/my-decks/new/page.js
+++ b/app/(app)/my-decks/new/page.js
@@ -27,13 +27,11 @@ export default function Page() {
   const queryClient = useQueryClient()
 
   const createNewDeck = useMutation({
-    mutationFn: lang => postNewDeck(lang),
+    mutationFn: postNewDeck,
     onSuccess: data => {
       // console.log(`onSuccess data,`, data)
       queryClient.invalidateQueries({ queryKey: ['decks'] })
-      router.push(
-        `/my-decks/${data.insertIntoUserDeckCollection.records[0].lang}`
-      )
+      router.push(`/my-decks/${data.lang}`)
     },
   })
 

--- a/app/(app)/my-decks/new/page.js
+++ b/app/(app)/my-decks/new/page.js
@@ -16,7 +16,7 @@ const options = Object.keys(languages).map(lang => {
 })
 
 function TinyError({ text }) {
-  return <p className="my-4 text-red-700">{text}</p>
+  return <p className="my-4 text-error/70">{text}</p>
 }
 
 export default function Page() {

--- a/app/(site)/(browse)/language/[lang]/page.js
+++ b/app/(site)/(browse)/language/[lang]/page.js
@@ -8,7 +8,6 @@ export default async function LanguagePage({ params: { lang } }) {
   if (!languages[lang]) {
     return notFound()
   }
-  const languageName = languages[lang] || ''
 
   const language = await getLanguageDetails(lang)
   if (language === null) {
@@ -21,11 +20,11 @@ export default async function LanguagePage({ params: { lang } }) {
         &larr; Back to languages
       </Link>
       <h1 className="h1">
-        {languageName} ({lang})
+        {languages[lang]} ({lang})
       </h1>
       {!language?.phraseCollection?.edges?.length ? (
         <p>
-          We don&apos;t have any phrases for you to learn {languageName} yet.
+          We don&apos;t have any phrases for you to learn {languages[lang]} yet.
           But you can be the first to add one!
         </p>
       ) : (

--- a/app/(site)/(browse)/layout.js
+++ b/app/(site)/(browse)/layout.js
@@ -2,7 +2,7 @@ import Sidebar from 'app/components/Sidebar'
 
 export default function Layout({ children }) {
   return (
-    <div className="md:flex flex-row gap-6 bg-primary text-white">
+    <div className="md:flex flex-row bg-primary text-white">
       <Sidebar shy={true} />
       <div className="flex-grow py-6 px-min min-h-60vh">{children}</div>
     </div>

--- a/app/components/Card.js
+++ b/app/components/Card.js
@@ -8,8 +8,9 @@ export function TinyPhrase({ lang, text }) {
 
 function readStatus(status) {
   if (!status) return { emoji: '', classString: '' }
-  if (status === 'learned') return { emoji: `✅ `, classString: 'bg-green-200' }
-  if (status === 'active') return { emoji: `📖 `, classString: 'bg-blue-200' }
+  if (status === 'learned')
+    return { emoji: `✅ `, classString: 'bg-success/20' }
+  if (status === 'active') return { emoji: `📖 `, classString: 'bg-info/20' }
   return { emoji: `❌ `, classString: '' }
 }
 

--- a/app/components/Garlic.js
+++ b/app/components/Garlic.js
@@ -1,6 +1,6 @@
 import Image from 'next/image'
 
-const Garlic = ({ size = 50 }) => (
+const Garlic = ({ size = 50, className = '' }) => (
   <Image
     src="/images/garlic.png"
     alt="a smiling garlic"
@@ -9,6 +9,7 @@ const Garlic = ({ size = 50 }) => (
     style={{
       filter: 'drop-shadow(0px 0px 2px #fff)',
     }}
+    className={`place-self-center ${className}`}
   />
 )
 

--- a/app/components/Sidebar.js
+++ b/app/components/Sidebar.js
@@ -52,50 +52,52 @@ export default function Sidebar({ shy = false }) {
         } md:hidden top-0 left-0 right-0 bottom-0`}
         onClick={() => setIsOpen(false)}
       />
-      <nav
-        aria-label="Main navigation"
-        className={`overflow-y-auto overflow-x-hidden z-30 top-0 w-80 p-6 bg-[#efe9fb] text-gray-800 h-screen ${
-          isOpen ? 'fixed' : 'hidden'
-        } ${shy && !isOpen ? '' : 'md:sticky md:flex'}  flex-col gap-4`}
-      >
-        <span className="h4 flex flex-row items-center">
-          <Garlic size={50} />
-          Sunlo
-        </span>
-        {loading ? (
-          <Loading />
-        ) : (
-          <>
-            <Navlink href="/app/profile">
-              <p>{profile?.data.username}</p>
-              <p>{/*user?.email*/}</p>
-            </Navlink>
-            {myMenus.map(menu => (
-              <div key={menu.name}>
-                <p className="font-bold my-4">
-                  {menu.href ? (
-                    <Navlink href={menu.href}>{menu.name}</Navlink>
-                  ) : (
-                    menu.name
-                  )}
-                </p>
-                <ul className="flex flex-col gap-2">
-                  {menu.links?.map(i => (
-                    <li key={i.href}>
-                      <Navlink href={i.href}>{i.name}</Navlink>
-                    </li>
-                  ))}
-                </ul>
-              </div>
-            ))}
-            <p>
-              <button className="btn btn-quiet" onClick={() => signOut(`/`)}>
-                Sign out
-              </button>
-            </p>
-          </>
-        )}
-      </nav>
+      <div className="bg-white">
+        <nav
+          aria-label="Main navigation"
+          className={`overflow-y-auto overflow-x-hidden z-30 top-0 w-72 p-6 bg-primary/20 text-gray-800 h-screen ${
+            isOpen ? 'fixed' : 'hidden'
+          } ${shy && !isOpen ? '' : 'md:sticky md:flex'}  flex-col gap-4`}
+        >
+          <span className="h4 flex flex-row items-center">
+            <Garlic size={50} />
+            Sunlo
+          </span>
+          {loading ? (
+            <Loading />
+          ) : (
+            <>
+              <Navlink href="/app/profile">
+                <p>{profile?.data.username}</p>
+                <p>{/*user?.email*/}</p>
+              </Navlink>
+              {myMenus.map(menu => (
+                <div key={menu.name}>
+                  <p className="font-bold my-4">
+                    {menu.href ? (
+                      <Navlink href={menu.href}>{menu.name}</Navlink>
+                    ) : (
+                      menu.name
+                    )}
+                  </p>
+                  <ul className="flex flex-col gap-2">
+                    {menu.links?.map(i => (
+                      <li key={i.href}>
+                        <Navlink href={i.href}>{i.name}</Navlink>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              ))}
+              <p>
+                <button className="btn btn-quiet" onClick={() => signOut(`/`)}>
+                  Sign out
+                </button>
+              </p>
+            </>
+          )}
+        </nav>
+      </div>
     </>
   )
 }

--- a/app/components/Sidebar.js
+++ b/app/components/Sidebar.js
@@ -60,7 +60,7 @@ export default function Sidebar({ shy = false }) {
       >
         <span className="h4 flex flex-row items-center">
           <Garlic size={50} />
-          &nbsp; Sunlo
+          Sunlo
         </span>
         {loading ? (
           <Loading />

--- a/app/data/posters.ts
+++ b/app/data/posters.ts
@@ -2,7 +2,6 @@ import { request } from 'graphql-request'
 import supabase from 'lib/supabase-client'
 import { requestOptions } from './constants'
 import { newDeckMutation, newCardMutation } from 'app/data/mutations.js'
-// import type { CardPhraseFilter, UserDeckInsertInput } from './gql/graphql'
 
 export const postNewDeck = async (lang: string) => {
   // console.log(`postNewDeck ${lang}`)
@@ -19,7 +18,7 @@ export const postNewDeck = async (lang: string) => {
     document: newDeckMutation,
   })
   // console.log(`RESULT: `, result)
-  return result
+  return result.insertIntoUserDeckCollection.records[0]
 }
 
 export const postNewCard = async ({ status, phraseId, userDeckId }) => {

--- a/components/AppLayout.js
+++ b/components/AppLayout.js
@@ -17,7 +17,7 @@ export default function AppLayout({
         <meta property="og:image" content={image} />
         <meta name="theme-color" content="#570df8" />
       </Head>
-      <div className="md:flex flex-row gap-6 bg-primary text-white">
+      <div className="md:flex flex-row bg-primary text-white">
         <Sidebar />
         <div className="flex-grow py-6 px-min min-h-100vh">{children}</div>
       </div>

--- a/components/AppLayout.js
+++ b/components/AppLayout.js
@@ -19,7 +19,9 @@ export default function AppLayout({
       </Head>
       <div className="md:flex flex-row bg-primary text-white">
         <Sidebar />
-        <div className="flex-grow py-6 px-min min-h-100vh">{children}</div>
+        <div className="flex-grow py-6 px-min sm:px-2 md:px-6 lg:px-10 min-h-100vh">
+          {children}
+        </div>
       </div>
     </>
   )

--- a/components/DevData.js
+++ b/components/DevData.js
@@ -2,7 +2,7 @@ const DevData = ({ data }) => (
   <div className="rounded-md shadow-2xl bg-gray-800 mt-4">
     {data.map(([i, j]) => (
       <span key={i} className="overflow-hidden max-w-prose">
-        <h3 className="px-2 py-1 text-white bg-green-800">{i} data object</h3>
+        <h3 className="px-2 py-1 text-white bg-success/80">{i} data object</h3>
         <small className="text-white px-4 py-2 overflow-hidden">
           {JSON.stringify(j)}
         </small>

--- a/components/ErrorList.tsx
+++ b/components/ErrorList.tsx
@@ -11,8 +11,8 @@ const ErrorList = ({ summary, error, errors, asCard }: ErrorListProps) => {
 
   return !error && !errors?.length ? null : (
     <div className={`${asCard ? 'big-card' : ''} mt-6 mb-2`}>
-      {summary ? <p className="font-bold text-red-600">{summary}</p> : null}
-      <ul className="pl-5 text-red-600 list-disc">
+      {summary ? <p className="font-bold text-error/60">{summary}</p> : null}
+      <ul className="pl-5 text-error/60 list-disc">
         {errorString ? <li key={errorString}>{errorString}</li> : null}
         {errors
           ? errors.map(m => (

--- a/components/ForgotPasswordForm.js
+++ b/components/ForgotPasswordForm.js
@@ -29,7 +29,7 @@ export default function ForgotPasswordForm() {
   }
 
   return (
-    <div className="mx-auto max-w-lg my-6">
+    <div className="max-w-lg my-6">
       {successfulSubmit ? (
         <div className="flex flex-col space-y-4">
           <h1 className="h3 text-gray-700">Check your email</h1>
@@ -52,10 +52,10 @@ export default function ForgotPasswordForm() {
                   aria-invalid={errors?.email ? 'true' : 'false'}
                   className={`${
                     errors?.email ? 'border-error/60' : ''
-                  } rounded-md`}
+                  } rounded-md w-full`}
                   tabIndex="1"
                   type="text"
-                  placeholder="email"
+                  placeholder="email@domain"
                 />
               </div>
               <div className="flex flex-row justify-between">

--- a/components/ForgotPasswordForm.js
+++ b/components/ForgotPasswordForm.js
@@ -29,7 +29,7 @@ export default function ForgotPasswordForm() {
   }
 
   return (
-    <div className="max-w-lg my-6">
+    <div className="section-card-inner">
       {successfulSubmit ? (
         <div className="flex flex-col space-y-4">
           <h1 className="h3 text-gray-700">Check your email</h1>

--- a/components/ForgotPasswordForm.js
+++ b/components/ForgotPasswordForm.js
@@ -51,7 +51,7 @@ export default function ForgotPasswordForm() {
                   required="required"
                   aria-invalid={errors?.email ? 'true' : 'false'}
                   className={`${
-                    errors?.email ? 'border-red-600' : ''
+                    errors?.email ? 'border-error/60' : ''
                   } rounded-md`}
                   tabIndex="1"
                   type="text"

--- a/components/LoginForm.js
+++ b/components/LoginForm.js
@@ -57,7 +57,7 @@ export default function Login({ signup }) {
   }
 
   return (
-    <div className="max-w-lg">
+    <div className="section-card-inner">
       {sentConfirmationEmail ? (
         <SuccessfulSubmit />
       ) : (

--- a/components/LoginForm.js
+++ b/components/LoginForm.js
@@ -14,7 +14,7 @@ export default function Login({ signup }) {
 
   const router = useRouter()
   const { user, profile, signOut } = useGlobalState()
-
+  if (profile && user) router.push('/app/profile')
   // const [isSignup, setIsSignup] = useState(signup)
 
   const onSubmit = event => {
@@ -60,27 +60,6 @@ export default function Login({ signup }) {
     <div className="mx-auto max-w-lg my-6">
       {sentConfirmationEmail ? (
         <SuccessfulSubmit />
-      ) : user && profile ? (
-        <div className="flex flex-col space-y-4">
-          <h1 className="h3 text-gray-700">
-            You&apos;re logged in as {profile.username}
-          </h1>
-          <p>
-            <Link href="/app/profile" className="link">
-              Skip logging in again and go to my profile
-            </Link>
-          </p>
-          <p>
-            <a
-              className="link"
-              onClick={() => {
-                signOut(`/login`)
-              }}
-            >
-              Log out and log in as someone new
-            </a>
-          </p>
-        </div>
       ) : (
         <>
           <h1 className="h3 text-gray-700">

--- a/components/LoginForm.js
+++ b/components/LoginForm.js
@@ -57,7 +57,7 @@ export default function Login({ signup }) {
   }
 
   return (
-    <div className="mx-auto max-w-lg my-6">
+    <div className="max-w-lg">
       {sentConfirmationEmail ? (
         <SuccessfulSubmit />
       ) : (
@@ -78,10 +78,10 @@ export default function Login({ signup }) {
                   aria-invalid={errors?.email ? 'true' : 'false'}
                   className={`${
                     errors?.email ? 'border-error/60' : ''
-                  } rounded-md`}
+                  } rounded-md w-full`}
                   tabIndex="1"
                   type="text"
-                  placeholder="email"
+                  placeholder="email@domain"
                 />
               </div>
               <div>
@@ -95,10 +95,10 @@ export default function Login({ signup }) {
                   aria-invalid={errors?.password ? 'true' : 'false'}
                   className={`${
                     errors?.password ? 'border-error/60' : ''
-                  } rounded-md`}
+                  } rounded-md w-full`}
                   tabIndex="2"
                   type="password"
-                  placeholder="****"
+                  placeholder="* * * * * * * *"
                 />
               </div>
               <div className="flex flex-row justify-between">

--- a/components/LoginForm.js
+++ b/components/LoginForm.js
@@ -98,7 +98,7 @@ export default function Login({ signup }) {
                   required="required"
                   aria-invalid={errors?.email ? 'true' : 'false'}
                   className={`${
-                    errors?.email ? 'border-red-600' : ''
+                    errors?.email ? 'border-error/60' : ''
                   } rounded-md`}
                   tabIndex="1"
                   type="text"
@@ -115,7 +115,7 @@ export default function Login({ signup }) {
                   required="required"
                   aria-invalid={errors?.password ? 'true' : 'false'}
                   className={`${
-                    errors?.password ? 'border-red-600' : ''
+                    errors?.password ? 'border-error/60' : ''
                   } rounded-md`}
                   tabIndex="2"
                   type="password"

--- a/components/PhraseCardSmall.js
+++ b/components/PhraseCardSmall.js
@@ -8,8 +8,9 @@ export function TinyPhrase({ lang, text }) {
 
 function readStatus(status) {
   if (!status) return { emoji: '', classString: '' }
-  if (status === 'learned') return { emoji: `✅ `, classString: 'bg-green-200' }
-  if (status === 'active') return { emoji: `📖 `, classString: 'bg-blue-200' }
+  if (status === 'learned')
+    return { emoji: `✅ `, classString: 'bg-success/20' }
+  if (status === 'active') return { emoji: `📖 `, classString: 'bg-info/20' }
   return { emoji: `❌ `, classString: '' }
 }
 

--- a/components/SetNewEmailForm.js
+++ b/components/SetNewEmailForm.js
@@ -25,7 +25,7 @@ export default function SetNewEmailForm() {
   }
 
   return (
-    <div className="mx-auto max-w-lg my-6">
+    <div className="max-w-lg">
       {successfulSubmit ? (
         <SuccessfulSubmit />
       ) : (
@@ -47,10 +47,10 @@ export default function SetNewEmailForm() {
                   aria-invalid={errors?.email ? 'true' : 'false'}
                   className={`${
                     errors?.email ? 'border-error/60' : ''
-                  } rounded-md`}
+                  } rounded-md w-full`}
                   tabIndex="1"
                   type="text"
-                  placeholder="email"
+                  placeholder="email@domain"
                   defaultValue={user?.email}
                 />
               </div>

--- a/components/SetNewEmailForm.js
+++ b/components/SetNewEmailForm.js
@@ -25,7 +25,7 @@ export default function SetNewEmailForm() {
   }
 
   return (
-    <div className="max-w-lg">
+    <div className="section-card-inner">
       {successfulSubmit ? (
         <SuccessfulSubmit />
       ) : (

--- a/components/SetNewEmailForm.js
+++ b/components/SetNewEmailForm.js
@@ -46,7 +46,7 @@ export default function SetNewEmailForm() {
                   required="required"
                   aria-invalid={errors?.email ? 'true' : 'false'}
                   className={`${
-                    errors?.email ? 'border-red-600' : ''
+                    errors?.email ? 'border-error/60' : ''
                   } rounded-md`}
                   tabIndex="1"
                   type="text"

--- a/components/SetNewPasswordForm.js
+++ b/components/SetNewPasswordForm.js
@@ -46,7 +46,7 @@ export default function SetNewPasswordForm() {
                   required="required"
                   aria-invalid={errors?.password ? 'true' : 'false'}
                   className={`${
-                    errors?.password ? 'border-red-600' : ''
+                    errors?.password ? 'border-error/60' : ''
                   } rounded-md`}
                   tabIndex="1"
                   type="password"

--- a/components/SetNewPasswordForm.js
+++ b/components/SetNewPasswordForm.js
@@ -26,7 +26,7 @@ export default function SetNewPasswordForm() {
   }
 
   return (
-    <div className="max-w-lg my-6">
+    <div className="section-card-inner">
       {successfulSubmit ? (
         <SuccessfulSubmit />
       ) : !user ? (

--- a/components/SetNewPasswordForm.js
+++ b/components/SetNewPasswordForm.js
@@ -26,7 +26,7 @@ export default function SetNewPasswordForm() {
   }
 
   return (
-    <div className="mx-auto max-w-lg my-6">
+    <div className="max-w-lg my-6">
       {successfulSubmit ? (
         <SuccessfulSubmit />
       ) : !user ? (
@@ -47,7 +47,7 @@ export default function SetNewPasswordForm() {
                   aria-invalid={errors?.password ? 'true' : 'false'}
                   className={`${
                     errors?.password ? 'border-error/60' : ''
-                  } rounded-md`}
+                  } rounded-md w-full`}
                   tabIndex="1"
                   type="password"
                   placeholder="new password"

--- a/components/old/Sidebar.js
+++ b/components/old/Sidebar.js
@@ -62,48 +62,50 @@ export default function Sidebar({ shy = false }) {
         } md:hidden top-0 left-0 right-0 bottom-0`}
         onClick={() => setIsOpen(false)}
       />
-      <nav
-        aria-label="Main navigation"
-        className={`overflow-y-auto overflow-x-hidden z-30 top-0 w-80 p-6 bg-[#efe9fb] text-gray-800 h-screen ${
-          isOpen ? 'fixed' : 'hidden'
-        } ${shy && !isOpen ? '' : 'md:sticky md:flex'}  flex-col gap-4`}
-      >
-        <span className="h4 flex flex-row items-center">
-          <Garlic size={50} />
-          &nbsp; Sunlo
-        </span>
-        {isLoading ? null : (
-          <>
-            <Navlink href="/app/profile">
-              <p>{profile?.username}</p>
-              <p>{user?.email}</p>
-            </Navlink>
-            {myMenus.map(menu => (
-              <div key={menu.name}>
-                <p className="font-bold my-4">
-                  {menu.href ? (
-                    <Navlink href={menu.href}>{menu.name}</Navlink>
-                  ) : (
-                    menu.name
-                  )}
-                </p>
-                <ul className="flex flex-col gap-2">
-                  {menu.links?.map(i => (
-                    <li key={i.href}>
-                      <Navlink href={i.href}>{i.name}</Navlink>
-                    </li>
-                  ))}
-                </ul>
-              </div>
-            ))}
-            <p>
-              <button className="btn btn-quiet" onClick={() => signOut(`/`)}>
-                Sign out
-              </button>
-            </p>
-          </>
-        )}
-      </nav>
+      <div className="bg-white">
+        <nav
+          aria-label="Main navigation"
+          className={`overflow-y-auto overflow-x-hidden z-30 top-0 w-72 p-6 bg-primary/20 text-gray-800 h-screen ${
+            isOpen ? 'fixed' : 'hidden'
+          } ${shy && !isOpen ? '' : 'md:sticky md:flex'}  flex-col gap-4`}
+        >
+          <span className="h4 flex flex-row items-center">
+            <Garlic size={50} />
+            &nbsp; Sunlo
+          </span>
+          {isLoading ? null : (
+            <>
+              <Navlink href="/app/profile">
+                <p>{profile?.username}</p>
+                <p>{user?.email}</p>
+              </Navlink>
+              {myMenus.map(menu => (
+                <div key={menu.name}>
+                  <p className="font-bold my-4">
+                    {menu.href ? (
+                      <Navlink href={menu.href}>{menu.name}</Navlink>
+                    ) : (
+                      menu.name
+                    )}
+                  </p>
+                  <ul className="flex flex-col gap-2">
+                    {menu.links?.map(i => (
+                      <li key={i.href}>
+                        <Navlink href={i.href}>{i.name}</Navlink>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              ))}
+              <p>
+                <button className="btn btn-quiet" onClick={() => signOut(`/`)}>
+                  Sign out
+                </button>
+              </p>
+            </>
+          )}
+        </nav>
+      </div>
     </>
   )
 }

--- a/lib/global-store.js
+++ b/lib/global-store.js
@@ -1,6 +1,6 @@
 'use client'
 
-import { createContext, useState, useEffect, useContext, useMemo } from 'react'
+import { createContext, useState, useEffect, useContext } from 'react'
 import supabase from 'lib/supabase-client'
 import { useRouter } from 'next/navigation'
 import { prependAndDedupe } from './data-helpers'
@@ -46,7 +46,6 @@ export function GlobalStateProvider({ children }) {
   const [loadingProfile, setLoadingProfile] = useState(false)
   const [profileResponse, setProfileResponse] = useState()
   const [profileError, setProfileError] = useState()
-  const [loadedCards, setLoadedCards] = useState()
 
   const router = useRouter()
 
@@ -144,12 +143,6 @@ export function GlobalStateProvider({ children }) {
         return [...prev]
       }),
     isLoading: loadingUser || loadingProfile,
-    loadedCards,
-    addLoadedCard: card =>
-      setLoadedCards(prev => {
-        prev[card.id] = card
-        return { ...prev }
-      }),
   }
 
   console.log(`render GlobalStateContext.Provider`)

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,12 +24,12 @@
         "@tailwindcss/typography": "^0.5.8",
         "@tanstack/react-query-devtools": "^4.24.12",
         "autoprefixer": "^10.4.13",
-        "daisyui": "^2.46.0",
+        "daisyui": "^2.51.4",
         "eslint": "8.30.0",
         "eslint-config-next": "13.1.1",
         "postcss": "^8.4.20",
         "prettier": "2.8.1",
-        "tailwindcss": "^3.2.4",
+        "tailwindcss": "^3.2.7",
         "typescript": "^4.9.5"
       }
     },
@@ -3832,9 +3832,9 @@
       }
     },
     "node_modules/daisyui": {
-      "version": "2.46.0",
-      "resolved": "https://registry.npmjs.org/daisyui/-/daisyui-2.46.0.tgz",
-      "integrity": "sha512-7L+KMCADsAmZkJUIabgDSpqEF9+uVPvyJSkSieOpY2WKeDd2pvcELZMs/AKaKkB5gcrb9cPP9vFdLXeDFJj90g==",
+      "version": "2.51.4",
+      "resolved": "https://registry.npmjs.org/daisyui/-/daisyui-2.51.4.tgz",
+      "integrity": "sha512-TGYD2BQCduxkKbDALlaWWaUdi33tryUuO/MxxBtAmLJ9zKn04gF6xduMxbrAUesR4AFr6LZW187TqF2H5c1AoA==",
       "dev": true,
       "dependencies": {
         "color": "^4.2",
@@ -7975,9 +7975,9 @@
       }
     },
     "node_modules/tailwindcss": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.2.4.tgz",
-      "integrity": "sha512-AhwtHCKMtR71JgeYDaswmZXhPcW9iuI9Sp2LvZPo9upDZ7231ZJ7eA9RaURbhpXGVlrjX4cFNlB4ieTetEb7hQ==",
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.2.7.tgz",
+      "integrity": "sha512-B6DLqJzc21x7wntlH/GsZwEXTBttVSl1FtCzC8WP4oBc/NKef7kaax5jeihkkCEWc831/5NDJ9gRNDK6NEioQQ==",
       "dev": true,
       "dependencies": {
         "arg": "^5.0.2",
@@ -7994,12 +7994,12 @@
         "normalize-path": "^3.0.0",
         "object-hash": "^3.0.0",
         "picocolors": "^1.0.0",
-        "postcss": "^8.4.18",
+        "postcss": "^8.0.9",
         "postcss-import": "^14.1.0",
         "postcss-js": "^4.0.0",
         "postcss-load-config": "^3.1.4",
         "postcss-nested": "6.0.0",
-        "postcss-selector-parser": "^6.0.10",
+        "postcss-selector-parser": "^6.0.11",
         "postcss-value-parser": "^4.2.0",
         "quick-lru": "^5.1.1",
         "resolve": "^1.22.1"
@@ -8013,6 +8013,19 @@
       },
       "peerDependencies": {
         "postcss": "^8.0.9"
+      }
+    },
+    "node_modules/tailwindcss/node_modules/postcss-selector-parser": {
+      "version": "6.0.11",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.11.tgz",
+      "integrity": "sha512-zbARubNdogI9j7WY4nQJBiNqQf3sLS3wCP4WfOidu+p28LofJqDH1tcXypGrcmMHhDk2t9wGhCsYe/+szLTy1g==",
+      "dev": true,
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/tapable": {

--- a/package.json
+++ b/package.json
@@ -21,18 +21,18 @@
   "devDependencies": {
     "@graphql-codegen/cli": "3.2.2",
     "@graphql-codegen/client-preset": "2.1.1",
+    "@graphql-codegen/introspection": "3.0.1",
     "@tailwindcss/forms": "^0.5.3",
     "@tailwindcss/line-clamp": "^0.4.2",
     "@tailwindcss/typography": "^0.5.8",
     "@tanstack/react-query-devtools": "^4.24.12",
     "autoprefixer": "^10.4.13",
-    "daisyui": "^2.46.0",
+    "daisyui": "^2.51.4",
     "eslint": "8.30.0",
     "eslint-config-next": "13.1.1",
     "postcss": "^8.4.20",
     "prettier": "2.8.1",
-    "tailwindcss": "^3.2.4",
-    "@graphql-codegen/introspection": "3.0.1",
+    "tailwindcss": "^3.2.7",
     "typescript": "^4.9.5"
   }
 }

--- a/pages/app/profile/change-email-success.js
+++ b/pages/app/profile/change-email-success.js
@@ -5,7 +5,7 @@ export default function ChangePassword() {
   const { user } = useGlobalState()
   return (
     <AppProfileLayout>
-      <main className="big-card">
+      <main className="section-card">
         {user ? (
           <div className="flex flex-col space-y-4">
             <h1 className="h3 text-gray-700">Email address changed!</h1>

--- a/pages/app/profile/change-email.js
+++ b/pages/app/profile/change-email.js
@@ -4,7 +4,7 @@ import SetNewEmailForm from 'components/SetNewEmailForm'
 export default function ChangePassword() {
   return (
     <AppProfileLayout>
-      <main className="big-card p-10">
+      <main className="section-card">
         <SetNewEmailForm />
       </main>
     </AppProfileLayout>

--- a/pages/app/profile/change-email.js
+++ b/pages/app/profile/change-email.js
@@ -4,7 +4,7 @@ import SetNewEmailForm from 'components/SetNewEmailForm'
 export default function ChangePassword() {
   return (
     <AppProfileLayout>
-      <main className="big-card">
+      <main className="big-card p-10">
         <SetNewEmailForm />
       </main>
     </AppProfileLayout>

--- a/pages/app/profile/change-password.js
+++ b/pages/app/profile/change-password.js
@@ -4,7 +4,7 @@ import SetNewPasswordForm from 'components/SetNewPasswordForm'
 export default function ChangePassword() {
   return (
     <AppProfileLayout>
-      <main className="big-card">
+      <main className="section-card">
         <SetNewPasswordForm />
       </main>
     </AppProfileLayout>

--- a/pages/app/profile/index.js
+++ b/pages/app/profile/index.js
@@ -42,82 +42,87 @@ const ProfileCard = () => {
       })
   }
 
-  return !profile || isLoading ? (
-    <Loading />
-  ) : (
+  return (
     <form className="big-card flex flex-col space-y-4" onSubmit={onSubmit}>
       <h2 className="h3">Profile</h2>
-      <fieldset
-        className="grid grid-cols-1 sm:grid-cols-2 gap-4"
-        disabled={!profile || isSubmitting}
-      >
-        <div className="flex flex-col">
-          <label htmlFor="username" className="font-bold px-3">
-            Your nickname
-          </label>
-          <input
-            id="username"
-            type="text"
-            className="border rounded p-3"
-            name="username"
-            tabIndex="1"
-            defaultValue={profile?.username || ''}
-          />
-        </div>
-        <div className="flex flex-col">
-          <label htmlFor="language_primary" className="font-bold px-3">
-            Primary language
-          </label>
-          <select
-            name="language_primary"
-            defaultValue={profile.language_primary || ''}
-            className="border rounded p-3"
-          >
-            <option value="">-- select one --</option>
-            {Object.keys(languages).map(k => (
-              <option key={`language-primary-${k}`} value={k}>
-                {languages[k]}
-              </option>
-            ))}
-          </select>
-        </div>
-        <div className="flex flex-col">
-          <label htmlFor="languages_spoken" className="font-bold px-3">
-            Languages you know
-          </label>
-          <div className="py-3 border rounded overflow-auto h-40">
-            {Object.keys(languages).map(k => (
-              <p key={`languages-spoken-${k}`} className="flex">
-                <label className="group-checked:bg-primary group-checked:text-white w-full px-3 py-1">
-                  <input
-                    type="checkbox"
-                    className={`rounded mr-2 focus:outline-gray-400 select-none checked-${
-                      profile.languages_spoken.indexOf(k) !== -1 ||
-                      k === profile.language_primary
-                    }`}
-                    value={k}
-                    name="languages_spoken"
-                    defaultChecked={
-                      profile.languages_spoken.indexOf(k) !== -1 ||
-                      k === profile.language_primary
-                    }
-                  />
-                  {languages[k]}
-                </label>
-              </p>
-            ))}
+      {!profile || isLoading ? (
+        <Loading />
+      ) : (
+        <fieldset
+          className="grid grid-cols-1 sm:grid-cols-2 gap-4"
+          disabled={!profile || isSubmitting}
+        >
+          <div className="flex flex-col">
+            <label htmlFor="username" className="font-bold px-3">
+              Your nickname
+            </label>
+            <input
+              id="username"
+              type="text"
+              className="border rounded p-3"
+              name="username"
+              tabIndex="1"
+              defaultValue={profile?.username || ''}
+            />
           </div>
-        </div>
-        <div className="flex flex-col-reverse">
-          <button
-            className="btn btn-primary"
-            disabled={!profile || isSubmitting}
-          >
-            Save changes
-          </button>
-        </div>
-        <ErrorList summary="Problem updating profile" error={errors?.message} />
-      </fieldset>
+          <div className="flex flex-col">
+            <label htmlFor="language_primary" className="font-bold px-3">
+              Primary language
+            </label>
+            <select
+              name="language_primary"
+              defaultValue={profile.language_primary || ''}
+              className="border rounded p-3"
+            >
+              <option value="">-- select one --</option>
+              {Object.keys(languages).map(k => (
+                <option key={`language-primary-${k}`} value={k}>
+                  {languages[k]}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div className="flex flex-col">
+            <label htmlFor="languages_spoken" className="font-bold px-3">
+              Languages you know
+            </label>
+            <div className="py-3 border rounded overflow-auto h-40">
+              {Object.keys(languages).map(k => (
+                <p key={`languages-spoken-${k}`} className="flex">
+                  <label className="group-checked:bg-primary group-checked:text-white w-full px-3 py-1">
+                    <input
+                      type="checkbox"
+                      className={`rounded mr-2 focus:outline-gray-400 select-none checked-${
+                        profile.languages_spoken.indexOf(k) !== -1 ||
+                        k === profile.language_primary
+                      }`}
+                      value={k}
+                      name="languages_spoken"
+                      defaultChecked={
+                        profile.languages_spoken.indexOf(k) !== -1 ||
+                        k === profile.language_primary
+                      }
+                    />
+                    {languages[k]}
+                  </label>
+                </p>
+              ))}
+            </div>
+          </div>
+          <div className="flex flex-col-reverse">
+            <button
+              className="btn btn-primary"
+              disabled={!profile || isSubmitting}
+            >
+              Save changes
+            </button>
+          </div>
+          <ErrorList
+            summary="Problem updating profile"
+            error={errors?.message}
+          />
+        </fieldset>
+      )}
     </form>
   )
 }

--- a/pages/login.js
+++ b/pages/login.js
@@ -7,7 +7,7 @@ export default function Login() {
     <SiteLayout>
       <main>
         <Banner>
-          <div className="card shadow-lg bg-white text-gray-800 max-w-lg py-10">
+          <div className="card shadow-lg bg-white text-gray-800 max-w-lg p-10">
             <LoginForm />
           </div>
         </Banner>

--- a/pages/login.js
+++ b/pages/login.js
@@ -7,7 +7,7 @@ export default function Login() {
     <SiteLayout>
       <main>
         <Banner>
-          <div className="card shadow-lg bg-white text-gray-800 max-w-lg p-10">
+          <div className="section-card">
             <LoginForm />
           </div>
         </Banner>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -31,7 +31,7 @@
 
 @layer components {
   .btn-quiet {
-    @apply btn-link hover:underline hover:bg-[#efe9fb] border-transparent hover:border-white;
+    @apply btn-link hover:underline hover:bg-primary/10 border-transparent hover:border-white;
   }
   .btn-quiet-dark {
     @apply btn btn-outline border-none text-white hover:btn-secondary;

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -37,9 +37,20 @@
     @apply btn btn-outline border-none text-white hover:btn-secondary;
     background-color: hsla(var(--p) / var(--tw-bg-opacity, 1));
   }
+  /* used when you want a card section, width lg */
+  .section-card {
+    @apply card shadow-lg bg-white text-gray-800 max-w-lg p-10;
+  }
+  /* used inside .section-card to provide optional spacing and 
+  ability to use the section inside other elements */
+  .section-card-inner {
+    @apply max-w-lg md:px-4 lg:px-8;
+  }
+  /* used when you want a big card area, that goes as wide as prose */
   .big-card {
     @apply card bg-white text-gray-800 p-6 border shadow-lg mb-6 max-w-prose;
   }
+  /* used for a whole page */
   .page-card {
     @apply container mx-auto card bg-white text-gray-800 px-3 md:px-6 lg:px-10 border shadow-lg mb-6 pt-10 pb-16 min-h-50vh;
   }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -4,6 +4,7 @@ module.exports = {
     './app/**/*.{js,ts,jsx,tsx}',
     './pages/**/*.{js,ts,jsx,tsx}',
     './components/**/*.{js,ts,jsx,tsx}',
+    './styles/globals.css',
   ],
   theme: {
     screens: {


### PR DESCRIPTION
This is a "misc" PR, including:
* Remove dead code from global context object (one day we will retire this completely!)
* Simplify the return data from postNewDeck mutation
* Make the "new deck" screen more welcoming, with a little 🧄 telling you to start adding new cards, so you know everything is fine
* Standardize and DRY the classnames used by admin pages (like `login.js`) and the components they include (like `LoginForm`) so the outer ones use `section-card` and inner ones use `section-card-inner`
  * Notably, this also removes the `mx-auto` from those inner sections, which was causing them to shrink to their narrowest content; now the forms breath much better.
* The gap between the sidebar and main was combining with x-padding to create some asymmetry in the main area, so this PR removes that gap and leaves it to the responsibility of the main area, so the main area will have the same amount of breathing room on left and right, and that won't change when the sidebar opens or closes.
* Remove _all_ hardcoded color values (e.g. `text-red-700`) in favour of theme colors like `text-error/70`. DaisyUI is a littllel wonky and doesn't give `error-700` type colors so I had to use the transparency utility (`error/70`) which required wrapping the sidebar in a white-background div, but I think it was worth it. Now we can fullly support themes later, if we want.