### PR TITLE
Shrink the global context object down to only manage session and user

### DIFF
--- a/app/(app)/my-decks/new/page.js
+++ b/app/(app)/my-decks/new/page.js
@@ -26,7 +26,7 @@ export default function Page() {
     mutationFn: postNewDeck,
     onSuccess: data => {
       // console.log(`onSuccess data,`, data)
-      queryClient.invalidateQueries({ queryKey: ['decks'] })
+      queryClient.invalidateQueries({ queryKey: ['user_decks'] })
       router.push(`/my-decks/${data.lang}`)
     },
   })

--- a/app/components/Sidebar.js
+++ b/app/components/Sidebar.js
@@ -6,6 +6,7 @@ import Garlic from 'app/components/Garlic'
 import { staticMenu, convertDecksToMenu } from 'lib/menus'
 import { usePathname } from 'next/navigation'
 import { useProfile, useAllDecks } from 'app/data/hooks'
+import { useGlobalState } from 'lib/global-store'
 import Loading from 'app/loading'
 
 const Navlink = ({ href, children }) => {
@@ -35,6 +36,7 @@ export default function Sidebar({ shy = false }) {
     status: profileStatus,
     error: profileError,
   } = useProfile()
+  const { signOut } = useGlobalState()
 
   const loading = decksStatus === 'loading' || profileStatus === 'loading'
 

--- a/app/data/hooks.ts
+++ b/app/data/hooks.ts
@@ -105,7 +105,6 @@ export function useDeck(deckLang: string): UseQueryResult {
 export function usePhrase(id: Scalars['UUID']): UseQueryResult {
   return useQuery({
     queryKey: ['phrase', id],
-    // fix this. use queryKey[1]
     queryFn: async () => getPhraseDetails(id),
     enabled: !!id,
     staleTime: Infinity,

--- a/components/LoginForm.js
+++ b/components/LoginForm.js
@@ -13,8 +13,8 @@ export default function Login({ signup }) {
   const [sentConfirmationEmail, setSentConfirmationEmail] = useState()
 
   const router = useRouter()
-  const { user, profile, signOut } = useGlobalState()
-  if (profile && user) router.push('/app/profile')
+  const { session } = useGlobalState()
+  if (session) router.push('/my-decks')
   // const [isSignup, setIsSignup] = useState(signup)
 
   const onSubmit = event => {
@@ -46,7 +46,7 @@ export default function Login({ signup }) {
           setIsSubmitting(false)
           if (error) setErrors(error)
           if (data) {
-            router.push('/app/profile')
+            router.push('/my-decks')
           }
         })
         .catch(e => {

--- a/lib/data-helpers.js
+++ b/lib/data-helpers.js
@@ -8,11 +8,3 @@ export const convertNodeListToCheckedValues = list => {
   })
   return x
 }
-
-export const profileContextObject = profileResponseData => {
-  let { user_decks, ...user_profile } = profileResponseData
-  if (!user_profile) return { user_profile: null, user_decks: [] }
-  if (!user_decks) return { user_profile, user_decks: [] }
-
-  return { user_profile, user_decks }
-}

--- a/lib/data-helpers.js
+++ b/lib/data-helpers.js
@@ -8,3 +8,11 @@ export const convertNodeListToCheckedValues = list => {
   })
   return x
 }
+
+export const profileContextObject = profileResponseData => {
+  let { user_decks, ...user_profile } = profileResponseData
+  if (!user_profile) return { user_profile: null, user_decks: [] }
+  if (!user_decks) return { user_profile, user_decks: [] }
+
+  return { user_profile, user_decks }
+}

--- a/lib/global-store.js
+++ b/lib/global-store.js
@@ -3,7 +3,7 @@
 import { createContext, useState, useEffect, useContext } from 'react'
 import supabase from 'lib/supabase-client'
 import { useRouter } from 'next/navigation'
-import { prependAndDedupe } from './data-helpers'
+import { prependAndDedupe, profileContextObject } from './data-helpers'
 
 /* 
   Methods lifted shamelessly from 
@@ -20,24 +20,6 @@ const blankProfile = {
 }
 
 const GlobalStateContext = createContext(blankProfile)
-
-const profileContextObject = profileResponseData => {
-  // a successful profile response!
-  // extract decks to its own top-level item
-  // and calculate the publicURL of the avatar
-  if (!profileResponseData) return blankProfile
-  let { user_decks, ...user_profile } = profileResponseData
-
-  if (!user_profile) return blankProfile
-  if (!user_decks) return { profile: user_profile, decks: [] }
-
-  const { publicURL } = supabase.storage
-    .from('avatars')
-    .getPublicUrl(user_profile?.avatar_url)
-  if (publicURL) user_profile.avatar_public_url = publicURL
-
-  return { user_profile, user_decks }
-}
 
 export function GlobalStateProvider({ children }) {
   const [thisSession, setSession] = useState()

--- a/lib/global-store.js
+++ b/lib/global-store.js
@@ -70,7 +70,7 @@ export function GlobalStateProvider({ children }) {
     return () => {
       listener.subscription
     }
-  }, [])
+  }, [loadingUser, queryClient])
 
   useEffect(() => {
     if (!user?.id) {

--- a/lib/global-store.js
+++ b/lib/global-store.js
@@ -1,9 +1,9 @@
 'use client'
 
 import { createContext, useState, useEffect, useContext } from 'react'
+import { useQueryClient } from '@tanstack/react-query'
 import supabase from 'lib/supabase-client'
 import { useRouter } from 'next/navigation'
-import { prependAndDedupe, profileContextObject } from './data-helpers'
 
 /* 
   Methods lifted shamelessly from 
@@ -12,10 +12,8 @@ import { prependAndDedupe, profileContextObject } from './data-helpers'
 */
 
 const blankProfile = {
+  session: null,
   user: null,
-  profile: null,
-  profileError: null,
-  decks: null,
   isLoading: true,
 }
 
@@ -25,9 +23,8 @@ export function GlobalStateProvider({ children }) {
   const [thisSession, setSession] = useState()
   const [user, setUser] = useState()
   const [loadingUser, setLoadingUser] = useState(true)
-  const [loadingProfile, setLoadingProfile] = useState(false)
-  const [profileResponse, setProfileResponse] = useState()
-  const [profileError, setProfileError] = useState()
+
+  const queryClient = useQueryClient()
 
   const router = useRouter()
 
@@ -38,7 +35,7 @@ export function GlobalStateProvider({ children }) {
         setSession(session ?? null)
         setUser(session?.user ?? null)
         setLoadingUser(false)
-        setLoadingProfile(true)
+
         return
       })
 
@@ -52,17 +49,22 @@ export function GlobalStateProvider({ children }) {
         }
         if (event === 'SIGNED_OUT') {
           setLoadingUser(false)
-          setLoadingProfile(false)
           setUser(null)
           setSession(null)
-          setProfileResponse(null)
-          setProfileError(null)
+          queryClient.invalidateQueries([
+            'user_profile',
+            'user_decks',
+            'user_deck',
+          ])
         }
         if (event === 'SIGNED_IN') {
           setUser(session?.user ?? null)
           setSession(session)
-          setLoadingUser(false)
-          setLoadingProfile(true)
+          queryClient.invalidateQueries([
+            'user_profile',
+            'user_decks',
+            'user_deck',
+          ])
         }
       }
     )
@@ -72,43 +74,9 @@ export function GlobalStateProvider({ children }) {
     }
   }, [loadingUser, queryClient])
 
-  useEffect(() => {
-    if (!user?.id) {
-      setProfileResponse(null)
-      setLoadingProfile(loadingUser || false)
-    } else {
-      // user is done loading so we will run the async query
-      if (loadingProfile)
-        supabase
-          .from('user_profile')
-          .select(`*, user_decks:user_deck(id, lang)`)
-          .eq('uid', user.id)
-          .maybeSingle()
-          .then(({ data, error }) => {
-            if (error) {
-              setProfileError(error)
-            } else {
-              setProfileResponse(data)
-              // if there is a user but no profile this means they've missed
-              // the starting screen and need to find their way back
-              if (!data || data === [] || data === {})
-                router.push('/app/profile/start')
-            }
-            setLoadingProfile(false)
-          })
-    }
-  }, [user])
-
-  const { user_decks, user_profile } = profileResponse
-    ? profileContextObject(profileResponse)
-    : { user_decks: null, user_profile: null }
-
   const value = {
     session: thisSession,
     user,
-    profile: user_profile,
-    decks: user_decks,
-    profileError,
     signUp: data => supabase.auth.signUp(data),
     signIn: data => supabase.auth.signIn(data),
     signOut: path => {
@@ -116,16 +84,7 @@ export function GlobalStateProvider({ children }) {
         router?.push(path ?? '/')
       })
     },
-    mergeProfileData: data =>
-      setProfileResponse(prev => {
-        return { ...prev, ...data }
-      }),
-    insertDeckData: data =>
-      setProfileResponse(prev => {
-        prev.user_decks = prependAndDedupe(data, prev.user_decks)
-        return [...prev]
-      }),
-    isLoading: loadingUser || loadingProfile,
+    isLoading: loadingUser,
   }
 
   console.log(`render GlobalStateContext.Provider`)

--- a/lib/global-store.js
+++ b/lib/global-store.js
@@ -112,8 +112,9 @@ export function GlobalStateProvider({ children }) {
     signUp: data => supabase.auth.signUp(data),
     signIn: data => supabase.auth.signIn(data),
     signOut: path => {
-      supabase.auth.signOut()
-      router?.push(path ?? '/')
+      supabase.auth.signOut().then(() => {
+        router?.push(path ?? '/')
+      })
     },
     mergeProfileData: data =>
       setProfileResponse(prev => {

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,11 +1,14 @@
 import 'styles/globals.css'
 import { GlobalStateProvider } from 'lib/global-store'
+import Provider from 'app/Provider'
 
 function App({ Component, pageProps }) {
   return (
-    <GlobalStateProvider>
-      <Component {...pageProps} />
-    </GlobalStateProvider>
+    <Provider>
+      <GlobalStateProvider>
+        <Component {...pageProps} />
+      </GlobalStateProvider>
+    </Provider>
   )
 }
 

--- a/pages/app/profile/index.js
+++ b/pages/app/profile/index.js
@@ -58,6 +58,8 @@ const ProfileCard = () => {
       <h2 className="h3">Profile</h2>
       {profileStatus === 'loading' ? (
         <Loading />
+      ) : profileError ? (
+        <ErrorList error={profileError} />
       ) : (
         <fieldset
           className="grid grid-cols-1 sm:grid-cols-2 gap-4"

--- a/pages/app/profile/start.js
+++ b/pages/app/profile/start.js
@@ -108,7 +108,7 @@ export default function Page() {
           <div className="flex flex-col space-y-4">
             {tempDeckToAdd ? (
               <Link
-                href={`/deck/${tempDeckToAdd}`}
+                href={`/my-decks/${tempDeckToAdd}`}
                 className="mx-auto btn btn-secondary"
               >
                 Get started learning {languages[tempDeckToAdd]}


### PR DESCRIPTION
This PR replaces all uses of the global context object's `profile` and `decks` data with the `useProfile` hook, and replaces the helpers like `mergeProfileData` with simply invalidating the profile query, which results in a refetch and rerender. This required some surgery on the `/app/profile/start` page, which can be difficult to QA, so we'll keep an eye on it.