### PR TITLE
Replace GlobalStateProvider with AuthProvider

### DIFF
--- a/app/components/Sidebar.js
+++ b/app/components/Sidebar.js
@@ -6,7 +6,7 @@ import Garlic from 'app/components/Garlic'
 import { staticMenu, convertDecksToMenu } from 'lib/menus'
 import { usePathname } from 'next/navigation'
 import { useProfile, useAllDecks } from 'app/data/hooks'
-import { useGlobalState } from 'lib/global-store'
+import { useAuthContext } from 'lib/auth-context'
 import Loading from 'app/loading'
 
 const Navlink = ({ href, children }) => {
@@ -36,7 +36,7 @@ export default function Sidebar({ shy = false }) {
     status: profileStatus,
     error: profileError,
   } = useProfile()
-  const { signOut } = useGlobalState()
+  const { signOut } = useAuthContext()
 
   const loading = decksStatus === 'loading' || profileStatus === 'loading'
 

--- a/app/components/Sidebar.js
+++ b/app/components/Sidebar.js
@@ -4,10 +4,10 @@ import { useState, useEffect } from 'react'
 import Link from 'next/link'
 import Garlic from 'app/components/Garlic'
 import { staticMenu, convertDecksToMenu } from 'lib/menus'
-import { usePathname } from 'next/navigation'
+import { usePathname, useRouter } from 'next/navigation'
 import { useProfile, useAllDecks } from 'app/data/hooks'
-import { useAuthContext } from 'lib/auth-context'
 import Loading from 'app/loading'
+import supabase from 'lib/supabase-client'
 
 const Navlink = ({ href, children }) => {
   const pathname = usePathname()
@@ -29,6 +29,7 @@ const Navlink = ({ href, children }) => {
 export default function Sidebar({ shy = false }) {
   const [isOpen, setIsOpen] = useState(false)
   const pathname = usePathname()
+  const router = useRouter()
 
   const { data: decks, status: decksStatus, error: decksError } = useAllDecks()
   const {
@@ -36,7 +37,6 @@ export default function Sidebar({ shy = false }) {
     status: profileStatus,
     error: profileError,
   } = useProfile()
-  const { signOut } = useAuthContext()
 
   const loading = decksStatus === 'loading' || profileStatus === 'loading'
 
@@ -98,7 +98,14 @@ export default function Sidebar({ shy = false }) {
               </div>
             ))}
             <p>
-              <button className="btn btn-quiet" onClick={() => signOut(`/`)}>
+              <button
+                className="btn btn-quiet"
+                onClick={() =>
+                  supabase.auth.signOut().then(() => {
+                    router?.push('/')
+                  })
+                }
+              >
                 Sign out
               </button>
             </p>

--- a/components/LoginForm.js
+++ b/components/LoginForm.js
@@ -4,7 +4,7 @@ import { useState } from 'react'
 import Link from 'next/link'
 import { useRouter } from 'next/navigation'
 import supabase from 'lib/supabase-client'
-import { useGlobalState } from 'lib/global-store'
+import { useAuthContext } from 'lib/auth-context'
 import ErrorList from 'app/components/ErrorList'
 
 export default function Login({ signup }) {
@@ -13,8 +13,8 @@ export default function Login({ signup }) {
   const [sentConfirmationEmail, setSentConfirmationEmail] = useState()
 
   const router = useRouter()
-  const { session } = useGlobalState()
-  if (session) router.push('/my-decks')
+  const { user } = useAuthContext()
+  if (user) router.push('/my-decks')
   // const [isSignup, setIsSignup] = useState(signup)
 
   const onSubmit = event => {

--- a/components/SetNewEmailForm.js
+++ b/components/SetNewEmailForm.js
@@ -1,10 +1,10 @@
 import { useState } from 'react'
 import supabase from 'lib/supabase-client'
-import { useGlobalState } from 'lib/global-store'
+import { useAuthContext } from 'lib/auth-context'
 import ErrorList from 'app/components/ErrorList'
 
 export default function SetNewEmailForm() {
-  const { user } = useGlobalState()
+  const { user } = useAuthContext()
   const [errors, setErrors] = useState()
   const [isSubmitting, setIsSubmitting] = useState()
   const [successfulSubmit, setSuccessfulSubmit] = useState()

--- a/components/SetNewPasswordForm.js
+++ b/components/SetNewPasswordForm.js
@@ -2,10 +2,10 @@ import { useState } from 'react'
 import Link from 'next/link'
 import supabase from 'lib/supabase-client'
 import ErrorList from 'app/components/ErrorList'
-import { useGlobalState } from 'lib/global-store'
+import { useAuthContext } from 'lib/auth-context'
 
 export default function SetNewPasswordForm() {
-  const { user } = useGlobalState()
+  const { user } = useAuthContext()
   const [errors, setErrors] = useState()
   const [isSubmitting, setIsSubmitting] = useState()
   const [successfulSubmit, setSuccessfulSubmit] = useState()

--- a/lib/auth-context.js
+++ b/lib/auth-context.js
@@ -11,46 +11,43 @@ import { useRouter } from 'next/navigation'
   and https://ruanmartinelli.com/posts/supabase-authentication-react
 */
 
-const blankProfile = {
-  session: null,
+const blank = {
   user: null,
   isLoading: true,
 }
 
-const GlobalStateContext = createContext(blankProfile)
+const AuthContext = createContext(blank)
 
-export function GlobalStateProvider({ children }) {
-  const [thisSession, setSession] = useState()
-  const [user, setUser] = useState()
-  const [loadingUser, setLoadingUser] = useState(true)
+export function AuthProvider({ children }) {
+  const [user, setUser] = useState(null)
+  const [isLoading, setIsLoading] = useState(true)
 
   const queryClient = useQueryClient()
-
   const router = useRouter()
 
   useEffect(() => {
-    if (loadingUser)
-      supabase.auth.getSession().then(({ data: { session } }) => {
-        console.log('GlobalContext resolved getSession', session)
-        setSession(session ?? null)
-        setUser(session?.user ?? null)
-        setLoadingUser(false)
-
+    if (isLoading) {
+      console.log(`Fetching user from server session`)
+      // we're using the more expensive getUser instead of getSession to be
+      // extra sure that the session is valid because the user is only accessed
+      // on account management pages; everything else uses profile or nothing.
+      supabase.auth.getUser().then(({ data: { user } }) => {
+        setUser(user ?? null)
+        setIsLoading(false)
         return
       })
-
+    }
     const { data: listener } = supabase.auth.onAuthStateChange(
       async (event, session) => {
         // handles a logout event
-        console.log(`Supabase auth event:`, event)
+        console.log(`Auth state change:`, event)
         // 'SIGNED_IN', 'SIGNED_OUT', 'TOKEN_REFRESHED', 'USER_UPDATED', 'PASSWORD_RECOVERY'
         if (event === 'USER_UPDATED') {
           setUser(session?.user ?? null)
         }
         if (event === 'SIGNED_OUT') {
-          setLoadingUser(false)
+          setIsLoading(false)
           setUser(null)
-          setSession(null)
           queryClient.invalidateQueries([
             'user_profile',
             'user_decks',
@@ -59,7 +56,6 @@ export function GlobalStateProvider({ children }) {
         }
         if (event === 'SIGNED_IN') {
           setUser(session?.user ?? null)
-          setSession(session)
           queryClient.invalidateQueries([
             'user_profile',
             'user_decks',
@@ -72,11 +68,11 @@ export function GlobalStateProvider({ children }) {
     return () => {
       listener.subscription
     }
-  }, [loadingUser, queryClient])
+  }, [isLoading, queryClient])
 
   const value = {
-    session: thisSession,
     user,
+    isLoading,
     signUp: data => supabase.auth.signUp(data),
     signIn: data => supabase.auth.signIn(data),
     signOut: path => {
@@ -84,25 +80,20 @@ export function GlobalStateProvider({ children }) {
         router?.push(path ?? '/')
       })
     },
-    isLoading: loadingUser,
   }
 
-  console.log(`render GlobalStateContext.Provider`)
-  return (
-    <GlobalStateContext.Provider value={value}>
-      {children}
-    </GlobalStateContext.Provider>
-  )
+  console.log(`render AuthContext.Provider`)
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>
 }
 
-// a hook to use whenever we need to consume data from `GlobalStateProvider`.
-// So, We don't need React.useContext everywhere we need data from GlobalStateContext.
+// a hook to use whenever we need to consume data from `AuthProvider`.
+// So, We don't need React.useContext everywhere we need data from AuthContext.
 
-export function useGlobalState() {
-  const context = useContext(GlobalStateContext)
+export function useAuthContext() {
+  const context = useContext(AuthContext)
 
   if (!context) {
-    throw new Error('You need to wrap GlobalStateProvider.')
+    throw new Error('You need to wrap AuthProvider.')
   }
 
   return context

--- a/lib/auth-context.js
+++ b/lib/auth-context.js
@@ -3,10 +3,9 @@
 import { createContext, useState, useEffect, useContext } from 'react'
 import { useQueryClient } from '@tanstack/react-query'
 import supabase from 'lib/supabase-client'
-import { useRouter } from 'next/navigation'
 
 /* 
-  Methods lifted shamelessly from 
+  Methods adapted mostly from 
   https://dev.to/saisandeepvaddi/simple-way-to-manage-state-in-react-with-context-kig
   and https://ruanmartinelli.com/posts/supabase-authentication-react
 */
@@ -23,7 +22,6 @@ export function AuthProvider({ children }) {
   const [isLoading, setIsLoading] = useState(true)
 
   const queryClient = useQueryClient()
-  const router = useRouter()
 
   useEffect(() => {
     if (isLoading) {
@@ -73,13 +71,6 @@ export function AuthProvider({ children }) {
   const value = {
     user,
     isLoading,
-    signUp: data => supabase.auth.signUp(data),
-    signIn: data => supabase.auth.signIn(data),
-    signOut: path => {
-      supabase.auth.signOut().then(() => {
-        router?.push(path ?? '/')
-      })
-    },
   }
 
   console.log(`render AuthContext.Provider`)

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,13 +1,13 @@
 import 'styles/globals.css'
-import { GlobalStateProvider } from 'lib/global-store'
+import { AuthProvider } from 'lib/auth-context'
 import Provider from 'app/Provider'
 
 function App({ Component, pageProps }) {
   return (
     <Provider>
-      <GlobalStateProvider>
+      <AuthProvider>
         <Component {...pageProps} />
-      </GlobalStateProvider>
+      </AuthProvider>
     </Provider>
   )
 }

--- a/pages/app/profile/change-email-success.js
+++ b/pages/app/profile/change-email-success.js
@@ -1,8 +1,8 @@
 import AppProfileLayout from 'components/AppProfileLayout'
-import { useGlobalState } from 'lib/global-store'
+import { useAuthContext } from 'lib/auth-context'
 
 export default function ChangePassword() {
-  const { user } = useGlobalState()
+  const { user } = useAuthContext()
   return (
     <AppProfileLayout>
       <main className="section-card">

--- a/pages/app/profile/index.js
+++ b/pages/app/profile/index.js
@@ -3,7 +3,7 @@ import Link from 'next/link'
 import { useQueryClient } from '@tanstack/react-query'
 import supabase from 'lib/supabase-client'
 import AppProfileLayout from 'components/AppProfileLayout'
-import { useGlobalState } from 'lib/global-store'
+import { useAuthContext } from 'lib/auth-context'
 import ErrorList from 'app/components/ErrorList'
 import { convertNodeListToCheckedValues } from 'lib/data-helpers'
 import languages from 'lib/languages'
@@ -141,7 +141,7 @@ const ProfileCard = () => {
 }
 
 const UserAuthCard = () => {
-  const { user } = useGlobalState()
+  const { user } = useAuthContext()
   return (
     <div className="big-card flex flex-col space-y-4">
       <h2 className="h3">Login credentials</h2>

--- a/pages/app/profile/start.js
+++ b/pages/app/profile/start.js
@@ -1,6 +1,6 @@
 import { useState } from 'react'
 import BannerLayout from 'components/BannerLayout'
-import { useGlobalState } from 'lib/global-store'
+import { useAuthContext } from 'lib/auth-context'
 import supabase from 'lib/supabase-client'
 import ErrorList from 'app/components/ErrorList'
 import Link from 'next/link'
@@ -10,7 +10,7 @@ import { useQueryClient } from '@tanstack/react-query'
 import languages from 'lib/languages'
 
 export default function Page() {
-  const { user, isLoading } = useGlobalState()
+  const { user, isLoading } = useAuthContext()
   const {
     data: profile,
     status: profileStatus,


### PR DESCRIPTION
This PR will:
* replace the GlobalStateProvider with AuthProvider, useGlobalState to useAuthState etc.
* remove the last remnants of the session key from the context object (because it carries the access token so I just don't want it getting passed around any more than it has to)
* Also, since we are now very clearly only using this AuthContext in login pages and user management pages, we switched to the more expensive getUser which checks the current session against the database, just to be sure everything is up-to-date. This is probably unnecessary but it's a single HTTP request that may prevent some error handling later on, and it should only happen once ish, so why not 🤷 