### PR TITLE
Fix the signup flow

### DIFF
--- a/app/data/hooks.ts
+++ b/app/data/hooks.ts
@@ -118,11 +118,11 @@ export function useProfile(): UseQueryResult {
   const pathname = usePathname()
   return useQuery({
     queryKey: ['user_profile'],
-    queryFn: async (): Promise<Profile | null> => {
+    queryFn: async (): Promise<Profile | null | false> => {
       const {
         data: { session },
       } = await supabase.auth.getSession()
-      console.log('session is', session)
+      // console.log('session is', session)
       if (!session) return null
       const uid = session.user.id
       const { data, error } = await supabase
@@ -131,9 +131,10 @@ export function useProfile(): UseQueryResult {
         .eq('uid', uid)
         .maybeSingle()
       if (error) throw error
-      if (!data && pathname !== '/app/profile/start') {
-        router.push('/app/profile/start')
-      }
+      if (!data)
+        if (pathname !== '/app/profile/start') {
+          router.push('/app/profile/start')
+        } else return false
       return data || null
     },
     enabled: router && pathname ? true : false,

--- a/components/ForgotPasswordForm.js
+++ b/components/ForgotPasswordForm.js
@@ -2,6 +2,16 @@ import { useState } from 'react'
 import supabase from 'lib/supabase-client'
 import ErrorList from 'app/components/ErrorList'
 
+const baseUrl =
+  process.env.NEXT_PUBLIC_VERCEL_ENV === 'development'
+    ? 'http://localhost:3000'
+    : process.env.NEXT_PUBLIC_VERCEL_ENV === 'preview'
+    ? `https://${process.env.NEXT_PUBLIC_VERCEL_URL}`
+    : 'https://sunlo.co'
+
+const redirectUrl = `${baseUrl}/app/profile/change-password`
+console.log(`redirectUrl is ${redirectUrl}`)
+
 export default function ForgotPasswordForm() {
   const [errors, setErrors] = useState()
   const [isSubmitting, setIsSubmitting] = useState()
@@ -17,7 +27,7 @@ export default function ForgotPasswordForm() {
     setYourEmail(email)
     supabase.auth
       .resetPasswordForEmail(email, {
-        redirectTo: `https://www.sunlo.co/app/profile/change-password`,
+        redirectTo: redirectUrl,
       })
       .then(({ data, error }) => {
         setIsSubmitting(false)

--- a/components/ForgotPasswordForm.js
+++ b/components/ForgotPasswordForm.js
@@ -15,17 +15,21 @@ export default function ForgotPasswordForm() {
 
     const email = event.target.email.value
     setYourEmail(email)
-    supabase.auth.api.resetPasswordForEmail(email).then(({ data, error }) => {
-      setIsSubmitting(false)
-      if (!error) {
-        setSuccessfulSubmit(true)
-        setErrors()
-        console.log(data)
-      } else {
-        setErrors(error)
-        console.log(error)
-      }
-    })
+    supabase.auth
+      .resetPasswordForEmail(email, {
+        redirectTo: `https://www.sunlo.co/app/profile/change-password`,
+      })
+      .then(({ data, error }) => {
+        setIsSubmitting(false)
+        if (!error) {
+          setSuccessfulSubmit(true)
+          setErrors()
+          console.log(data)
+        } else {
+          setErrors(error)
+          console.log(error)
+        }
+      })
   }
 
   return (

--- a/components/LoginForm.js
+++ b/components/LoginForm.js
@@ -7,15 +7,13 @@ import supabase from 'lib/supabase-client'
 import { useAuthContext } from 'lib/auth-context'
 import ErrorList from 'app/components/ErrorList'
 
-export default function Login({ signup }) {
+export default function Login() {
   const [errors, setErrors] = useState()
   const [isSubmitting, setIsSubmitting] = useState()
-  const [sentConfirmationEmail, setSentConfirmationEmail] = useState()
 
   const router = useRouter()
   const { user } = useAuthContext()
   if (user) router.push('/my-decks')
-  // const [isSignup, setIsSignup] = useState(signup)
 
   const onSubmit = event => {
     setErrors()
@@ -24,122 +22,85 @@ export default function Login({ signup }) {
     const email = event.target.email.value
     const password = event.target.password.value
 
-    if (signup) {
-      supabase.auth
-        .signUp({ email, password })
-        .then(({ user, session, error }) => {
-          setIsSubmitting(false)
-          setErrors(error)
-          if (user && session) {
-            router.push('/app/profile/start')
-          } else if (user && !session) {
-            setSentConfirmationEmail(true)
-          }
-        })
-    } else {
-      supabase.auth
-        .signInWithPassword({
-          email,
-          password,
-        })
-        .then(({ data, error }) => {
-          setIsSubmitting(false)
-          if (error) setErrors(error)
-          if (data) {
-            router.push('/my-decks')
-          }
-        })
-        .catch(e => {
-          setIsSubmitting(false)
-          setErrors(e)
-        })
-    }
+    supabase.auth
+      .signInWithPassword({
+        email,
+        password,
+      })
+      .then(({ data, error }) => {
+        setIsSubmitting(false)
+        if (error) setErrors(error)
+        if (data) {
+          router.push('/my-decks')
+        }
+      })
+      .catch(e => {
+        setIsSubmitting(false)
+        setErrors(e)
+      })
   }
 
   return (
     <div className="section-card-inner">
-      {sentConfirmationEmail ? (
-        <SuccessfulSubmit />
-      ) : (
-        <>
-          <h1 className="h3 text-gray-700">
-            {signup ? 'Create your account' : 'Please log in'}
-          </h1>
-          <form role="form" onSubmit={onSubmit} className="form">
-            <fieldset className="flex flex-col gap-y-4" disabled={isSubmitting}>
-              <div>
-                <p>
-                  <label htmlFor="email">Email</label>
-                </p>
-                <input
-                  id="email"
-                  name="email"
-                  required="required"
-                  aria-invalid={errors?.email ? 'true' : 'false'}
-                  className={`${
-                    errors?.email ? 'border-error/60' : ''
-                  } rounded-md w-full`}
-                  tabIndex="1"
-                  type="text"
-                  placeholder="email@domain"
-                />
-              </div>
-              <div>
-                <p>
-                  <label htmlFor="password">Password</label>
-                </p>
-                <input
-                  id="password"
-                  name="password"
-                  required="required"
-                  aria-invalid={errors?.password ? 'true' : 'false'}
-                  className={`${
-                    errors?.password ? 'border-error/60' : ''
-                  } rounded-md w-full`}
-                  tabIndex="2"
-                  type="password"
-                  placeholder="* * * * * * * *"
-                />
-              </div>
-              <div className="flex flex-row justify-between">
-                <button
-                  tabIndex="3"
-                  className="btn btn-primary"
-                  type="submit"
-                  disabled={isSubmitting}
-                  aria-disabled={isSubmitting}
-                >
-                  {signup ? 'Sign up' : 'Log in'}
-                </button>
-                <Link
-                  tabIndex="4"
-                  href={signup ? '/login' : '/signup'}
-                  className="btn btn-quiet"
-                >
-                  {signup ? 'Log in' : 'Create account'}
-                </Link>
-              </div>
-              <ErrorList summary="Problem logging in" error={errors?.message} />
-              <p>
-                <Link href="/forgot-password" className="link text-sm">
-                  Forgot password?
-                </Link>
-              </p>
-            </fieldset>
-          </form>
-        </>
-      )}
+      <h1 className="h3 text-gray-700">Please log in</h1>
+      <form role="form" onSubmit={onSubmit} className="form">
+        <fieldset className="flex flex-col gap-y-4" disabled={isSubmitting}>
+          <div>
+            <p>
+              <label htmlFor="email">Email</label>
+            </p>
+            <input
+              id="email"
+              name="email"
+              required="required"
+              aria-invalid={errors?.email ? 'true' : 'false'}
+              className={`${
+                errors?.email ? 'border-error/60' : ''
+              } rounded-md w-full`}
+              tabIndex="1"
+              type="text"
+              placeholder="email@domain"
+            />
+          </div>
+          <div>
+            <p>
+              <label htmlFor="password">Password</label>
+            </p>
+            <input
+              id="password"
+              name="password"
+              required="required"
+              aria-invalid={errors?.password ? 'true' : 'false'}
+              className={`${
+                errors?.password ? 'border-error/60' : ''
+              } rounded-md w-full`}
+              tabIndex="2"
+              type="password"
+              placeholder="* * * * * * * *"
+            />
+          </div>
+          <div className="flex flex-row justify-between">
+            <button
+              tabIndex="3"
+              className="btn btn-primary"
+              type="submit"
+              disabled={isSubmitting}
+              aria-disabled={isSubmitting}
+            >
+              Log in
+            </button>
+            <Link tabIndex="4" href="/signup" className="btn btn-quiet">
+              Create account
+            </Link>
+          </div>
+          <ErrorList summary="Problem logging in" error={errors?.message} />
+          <p>
+            <Link href="/forgot-password" className="link text-sm">
+              Forgot password?
+            </Link>
+          </p>
+        </fieldset>
+      </form>
     </div>
   )
 }
-
-const SuccessfulSubmit = () => (
-  <div className="flex flex-col space-y-4 p-4 sm:p-6 md:p-10">
-    <h1 className="h3 text-gray-700">Please confirm email</h1>
-    <p>
-      We&apos;ve sent a confirmation email to the address you entered. Please
-      click the confirmation link in your email.
-    </p>
-    <p>You can close this tab.</p>
-  </div>
-)

--- a/components/SignupForm.js
+++ b/components/SignupForm.js
@@ -1,0 +1,116 @@
+'use client'
+
+import { useState } from 'react'
+import Link from 'next/link'
+import { useRouter } from 'next/navigation'
+import supabase from 'lib/supabase-client'
+import ErrorList from 'app/components/ErrorList'
+
+export default function Signup() {
+  const [errors, setErrors] = useState()
+  const [isSubmitting, setIsSubmitting] = useState()
+  const [sentConfirmationEmail, setSentConfirmationEmail] = useState()
+
+  const router = useRouter()
+
+  const onSubmit = event => {
+    setErrors()
+    setIsSubmitting(true)
+    event.preventDefault()
+    const email = event.target.email.value
+    const password = event.target.password.value
+
+    supabase.auth
+      .signUp({ email, password })
+      .then(({ user, session, error }) => {
+        setIsSubmitting(false)
+        setErrors(error)
+        if (user && session) {
+          router.push('/app/profile/start')
+        } else if (user && !session) {
+          setSentConfirmationEmail(true)
+        }
+      })
+  }
+
+  return (
+    <div className="section-card-inner">
+      {sentConfirmationEmail ? (
+        <SuccessfulSubmit />
+      ) : (
+        <>
+          <h1 className="h3 text-gray-700">Create your account</h1>
+          <form role="form" onSubmit={onSubmit} className="form">
+            <fieldset className="flex flex-col gap-y-4" disabled={isSubmitting}>
+              <div>
+                <p>
+                  <label htmlFor="email">Email</label>
+                </p>
+                <input
+                  id="email"
+                  name="email"
+                  required="required"
+                  aria-invalid={errors?.email ? 'true' : 'false'}
+                  className={`${
+                    errors?.email ? 'border-error/60' : ''
+                  } rounded-md w-full`}
+                  tabIndex="1"
+                  type="text"
+                  placeholder="email@domain"
+                />
+              </div>
+              <div>
+                <p>
+                  <label htmlFor="password">Password</label>
+                </p>
+                <input
+                  id="password"
+                  name="password"
+                  required="required"
+                  aria-invalid={errors?.password ? 'true' : 'false'}
+                  className={`${
+                    errors?.password ? 'border-error/60' : ''
+                  } rounded-md w-full`}
+                  tabIndex="2"
+                  type="password"
+                  placeholder="* * * * * * * *"
+                />
+              </div>
+              <div className="flex flex-row justify-between">
+                <button
+                  tabIndex="3"
+                  className="btn btn-primary"
+                  type="submit"
+                  disabled={isSubmitting}
+                  aria-disabled={isSubmitting}
+                >
+                  Sign up
+                </button>
+                <Link tabIndex="4" href="/login" className="btn btn-quiet">
+                  Log in
+                </Link>
+              </div>
+              <ErrorList summary="Problem logging in" error={errors?.message} />
+              <p>
+                <Link href="/forgot-password" className="link text-sm">
+                  Forgot password?
+                </Link>
+              </p>
+            </fieldset>
+          </form>
+        </>
+      )}
+    </div>
+  )
+}
+
+const SuccessfulSubmit = () => (
+  <div className="flex flex-col space-y-4 p-4 sm:p-6 md:p-10">
+    <h1 className="h3 text-gray-700">Please confirm email</h1>
+    <p>
+      We&apos;ve sent a confirmation email to the address you entered. Please
+      click the confirmation link in your email.
+    </p>
+    <p>You can close this tab.</p>
+  </div>
+)

--- a/lib/data-helpers.js
+++ b/lib/data-helpers.js
@@ -1,5 +1,5 @@
 export const prependAndDedupe = (item, items) =>
-  [item].concat(items.filter(i => i !== item))
+  [item].concat(items?.filter(i => i !== item))
 
 export const convertNodeListToCheckedValues = list => {
   let x = []

--- a/pages/app/profile/index.js
+++ b/pages/app/profile/index.js
@@ -56,10 +56,10 @@ const ProfileCard = () => {
   return (
     <form className="big-card flex flex-col space-y-4" onSubmit={onSubmit}>
       <h2 className="h3">Profile</h2>
-      {profileStatus === 'loading' ? (
-        <Loading />
-      ) : profileError ? (
+      {profileError ? (
         <ErrorList error={profileError} />
+      ) : profileStatus === 'loading' || !profile ? (
+        <Loading />
       ) : (
         <fieldset
           className="grid grid-cols-1 sm:grid-cols-2 gap-4"

--- a/pages/app/profile/start.js
+++ b/pages/app/profile/start.js
@@ -10,21 +10,9 @@ import { useQueryClient } from '@tanstack/react-query'
 import languages from 'lib/languages'
 
 export default function Page() {
-  const { user, isLoading } = useAuthContext()
-  const {
-    data: profile,
-    status: profileStatus,
-    error: profileError,
-  } = useProfile()
+  const { user } = useAuthContext()
+  const { data: profile } = useProfile()
   const queryClient = useQueryClient()
-
-  console.log(
-    `render Start, isLoading: ${
-      isLoading || profileStatus === 'loading'
-    }. User, Profile:`,
-    user,
-    profile
-  )
 
   const [tempLanguagePrimary, setTempLanguagePrimary] = useState()
   const tempLanguagePrimaryToUse =
@@ -53,7 +41,7 @@ export default function Page() {
         languages_spoken: newLanguagesSpoken,
       })
       .match({ uid: user.id })
-      .then(({ data, error }) => {
+      .then(({ error }) => {
         if (error) {
           setErrors(error)
           console.log('error upserting', error)
@@ -86,7 +74,7 @@ export default function Page() {
       })
   }
 
-  return !profile ? null : (
+  return profile === null ? null : (
     <BannerLayout>
       {successfulSetup ? (
         <div className="p2 md:p-6 lg:p-10 max-w-prose text-white min-h-85vh flex flex-col gap-12 justify-center">
@@ -230,11 +218,8 @@ const SetPrimaryLanguageStep = ({ value, set }) => {
 }
 
 const CreateFirstDeckStep = ({ value, set }) => {
-  const {
-    data: { user_decks: decks },
-    error,
-    status,
-  } = useProfile()
+  const { data } = useProfile()
+  const decks = data?.user_decks || []
   const [closed, setClosed] = useState(decks?.length > 0)
   return closed ? (
     <Completed>

--- a/pages/signup.js
+++ b/pages/signup.js
@@ -1,5 +1,5 @@
 import SiteLayout from 'components/SiteLayout'
-import LoginForm from 'components/LoginForm'
+import SignupForm from 'components/SignupForm'
 import Banner from 'app/components/Banner'
 
 export default function Login() {
@@ -8,7 +8,7 @@ export default function Login() {
       <main>
         <Banner>
           <div className="section-card">
-            <LoginForm signup />
+            <SignupForm />
           </div>
         </Banner>
       </main>

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -40,9 +40,9 @@ file_size_limit = "50MiB"
 [auth]
 # The base URL of your website. Used as an allow-list for redirects and for constructing URLs used
 # in emails.
-site_url = "http://localhost:3000"
+site_url = "https://sunlo.co"
 # A list of *exact* URLs that auth providers are permitted to redirect to post authentication.
-additional_redirect_urls = ["https://localhost:3000"]
+additional_redirect_urls = ["https://www.sunlo.co/app/profile/change-password", "http://localhost:3000/app/profile/change-password", "https://sunlo-nextjs-*-michaelsnook.vercel.app/app/profile/change-password"]
 # How long tokens are valid for, in seconds. Defaults to 3600 (1 hour), maximum 604,800 seconds (one
 # week).
 jwt_expiry = 3600


### PR DESCRIPTION
This PR:
* Splits signup and login pages
* Makes the useProfile hook check for a valid session but no profile, and if so, redirect to `/app/profile/start`
* Makes the start page work when there's no profile at all
* Fixes the forgot password form

For later?
* Move these forms to the app router?