### PR TITLE
Feature: edit card status + some related cleanup

### DIFF
--- a/app/(app)/my-decks/[lang]/Browse.jsx
+++ b/app/(app)/my-decks/[lang]/Browse.jsx
@@ -57,7 +57,7 @@ export default function Browse({ lang, disable }) {
           </a>
           <BigPhrase
             phrase_id={activePhraseId}
-            deck_id={data?.deck.id}
+            user_deck_id={data?.deck.id}
             // initialData={activePhraseData}
             onClose={() => handleChange('')}
             onNavigate={handleChange}

--- a/app/(app)/my-decks/[lang]/ClientPage.jsx
+++ b/app/(app)/my-decks/[lang]/ClientPage.jsx
@@ -52,7 +52,7 @@ export default function ClientPage({ lang }) {
       >
         <BigPhrase
           phrase_id={phraseModalId}
-          deck_id={deckData.id}
+          user_deck_id={deckData.id}
           onClose={() => setPhraseModalId('')}
           onNavigate={setPhraseModalId}
           noBox={true}

--- a/app/(app)/my-decks/[lang]/new-card/add-card.ts
+++ b/app/(app)/my-decks/[lang]/new-card/add-card.ts
@@ -10,15 +10,16 @@ type UserCardInsertInput = {
 
 export const postNewCard = async (
   object: UserCardInsertInput
-): Promise<CardStub | null> => {
+): Promise<CardStub> => {
   // console.log(`postNewCard`, object)
   const { data, error } = await supabase
     .from('user_card')
     .insert(object)
     .select()
-  // console.log(`postNewCard result: `, data, error)
   if (error) throw error
-  return data[0] || null
+
+  // console.log(`postNewCard result: `, data)
+  return data[0]
 }
 
 type PhraseInsertInput = {

--- a/app/(app)/my-decks/new/add-new-deck.ts
+++ b/app/(app)/my-decks/new/add-new-deck.ts
@@ -3,7 +3,7 @@
 import supabase from 'lib/supabase-client'
 import { DeckStub } from 'types/client-types'
 
-export const postNewDeck = async (lang: string): Promise<DeckStub | null> => {
+export const postNewDeck = async (lang: string): Promise<DeckStub> => {
   // console.log(`postNewDeck ${lang}`)
   if (typeof lang !== 'string' || lang.length !== 3)
     throw 'Form not right. Maybe refresh. Or tell the devs.'
@@ -13,5 +13,5 @@ export const postNewDeck = async (lang: string): Promise<DeckStub | null> => {
     .select()
   // console.log(`postNewDeck`, data, error)
   if (error) throw error
-  return data[0] ?? null
+  return data[0]
 }

--- a/app/components/BigPhrase.jsx
+++ b/app/components/BigPhrase.jsx
@@ -41,14 +41,14 @@ const AddCardButtonsSection = ({ phrase_id, deck_id, onClose }) => {
   })
   return (
     <div className="my-6 flex gap-8 text-2xl">
-      {makeNewCard.isLoading ? (
+      {makeNewCard.isSubmitting ? (
         <Loading />
       ) : makeNewCard.isError ? (
         <ErrorList error={makeNewCard.error} />
       ) : makeNewCard.isSuccess ? (
         <p className="text-lg">
-          Success! added this phrase to your deck with status: &ldquo;
-          {makeNewCard.data[0]?.status}
+          This phrase is in your deck with status: &ldquo;
+          {makeNewCard.data?.status}
           &rdquo;.&nbsp;
           <a href="#" className="text-primary link" onClick={onClose}>
             Keep browsing.

--- a/app/components/BigPhrase.jsx
+++ b/app/components/BigPhrase.jsx
@@ -9,14 +9,14 @@ import { toast } from 'react-hot-toast'
 import EditCardStatusButtons from './edit-status-buttons'
 import TinyPhrase from './TinyPhrase'
 
-const AddCardButtonsSection = ({ phrase_id, deck_id, onClose }) => {
+const AddCardButtonsSection = ({ phrase_id, user_deck_id, onClose }) => {
   const queryClient = useQueryClient()
   const makeNewCard = useMutation({
     mutationFn: status =>
       postNewCard({
         status,
         phrase_id,
-        user_deck_id: deck_id,
+        user_deck_id,
       }),
     onSuccess: data => {
       setTimeout(async () => {
@@ -81,7 +81,7 @@ const AddCardButtonsSection = ({ phrase_id, deck_id, onClose }) => {
 }
 
 export default function BigPhrase({
-  deck_id,
+  user_deck_id,
   phrase_id,
   onClose,
   onNavigate,
@@ -123,7 +123,7 @@ export default function BigPhrase({
             <EditCardStatusButtons cardId={card?.id} />
           ) : (
             <AddCardButtonsSection
-              deck_id={deck_id}
+              user_deck_id={user_deck_id}
               phrase_id={phrase_id}
               onClose={onClose}
             />

--- a/app/components/BigPhrase.jsx
+++ b/app/components/BigPhrase.jsx
@@ -8,13 +8,7 @@ import { postNewCard } from 'app/(app)/my-decks/[lang]/new-card/add-card'
 import { useQueryClient } from '@tanstack/react-query'
 import { toast } from 'react-hot-toast'
 import EditCardStatusButtons from './edit-status-buttons'
-
-export const TinyPhrase = ({ lang, text } /*: TinyPhraseProps*/) => (
-  <>
-    {lang ? <span className="text-gray-500">[{lang}]&nbsp;</span> : null}
-    &ldquo;{text}&rdquo;
-  </>
-)
+import TinyPhrase from './TinyPhrase'
 
 const AddCardButtonsSection = ({
   phrase_id,

--- a/app/components/BigPhrase.jsx
+++ b/app/components/BigPhrase.jsx
@@ -1,4 +1,3 @@
-// @ts-ignore
 'use client'
 
 import Loading from 'app/loading'
@@ -8,6 +7,7 @@ import { useMutation } from '@tanstack/react-query'
 import { postNewCard } from 'app/(app)/my-decks/[lang]/new-card/add-card'
 import { useQueryClient } from '@tanstack/react-query'
 import { toast } from 'react-hot-toast'
+import EditCardStatusButtons from './edit-status-buttons'
 
 export const TinyPhrase = ({ lang, text } /*: TinyPhraseProps*/) => (
   <>
@@ -15,26 +15,6 @@ export const TinyPhrase = ({ lang, text } /*: TinyPhraseProps*/) => (
     &ldquo;{text}&rdquo;
   </>
 )
-
-const EditCardButtonsSection = ({ userCardId, clearCache }) => {
-  const cardMutation = useMutation({
-    // mutationFn: status => editExistingCard(status, card.id)
-    mutationFn: status => {
-      console.log(`edit a card mutation here: ${status}, ${userCardId}`)
-    },
-    onSuccess: data => {
-      toast.success(`Card successfully updated with status: ${data.status}`)
-      console.log(`Card update return data:`, data)
-      clearCache(data)
-    },
-  })
-  return (
-    <p className="my-4">
-      there&apos;s already a card here and now you can modify it with buttons
-      &lt; button &gt;
-    </p>
-  )
-}
 
 const AddCardButtonsSection = ({
   phrase_id,
@@ -119,7 +99,7 @@ export default function BigPhrase({
   if (phraseStatus === 'loading') return <Loading />
 
   const translations = phrase?.translations
-  const userCard = phrase?.card
+  const card = phrase?.card
   // console.log(`bigPhrase look for userCard or phrase.card`, phrase)
   const seeAlsos = phrase?.see_also_phrases
 
@@ -148,12 +128,8 @@ export default function BigPhrase({
             seeAlsos={seeAlsos}
             onNavigate={onNavigate}
           />
-          {userCard ? (
-            <EditCardButtonsSection
-              userCardId={userCard?.id}
-              clearCache={clearCache}
-              onClose={onClose}
-            />
+          {card ? (
+            <EditCardStatusButtons cardId={card?.id} />
           ) : (
             <AddCardButtonsSection
               deck_id={deck_id}

--- a/app/components/Card.jsx
+++ b/app/components/Card.jsx
@@ -1,10 +1,4 @@
-export function TinyPhrase({ lang, text }) {
-  return (
-    <>
-      [{lang}] {text}
-    </>
-  )
-}
+import TinyPhrase from './TinyPhrase'
 
 function readStatus(status) {
   if (!status) return { emoji: '', classString: '' }
@@ -23,8 +17,7 @@ export default function Card({ status, phrase }) {
       className={`card p-4 ${classString} shadow-lg hover:bg-primary hover:text-white mb-4 w-full inline-block`}
     >
       <p lang={phrase?.lang} className="mb-2 font-bold">
-        {emoji}
-        <TinyPhrase {...phrase} />
+        <TinyPhrase {...phrase}>{emoji}</TinyPhrase>
       </p>
       {phrase?.translations?.length > 0 ? (
         <ul>

--- a/app/components/PhraseCardSmall.jsx
+++ b/app/components/PhraseCardSmall.jsx
@@ -1,10 +1,4 @@
-export function TinyPhrase({ lang, text }) {
-  return (
-    <>
-      [{lang}] {text}
-    </>
-  )
-}
+import TinyPhrase from './TinyPhrase'
 
 function readStatus(status) {
   if (!status) return { emoji: '', classString: '' }

--- a/app/components/TinyPhrase.jsx
+++ b/app/components/TinyPhrase.jsx
@@ -1,0 +1,9 @@
+const TinyPhrase = ({ lang, text, children }) => (
+  <p className="block">
+    {children}
+    {lang ? <span className="text-gray-500">[{lang}]&nbsp;</span> : null}
+    &ldquo;{text}&rdquo;
+  </p>
+)
+
+export default TinyPhrase

--- a/app/components/TinyPhrase.jsx
+++ b/app/components/TinyPhrase.jsx
@@ -1,9 +1,9 @@
 const TinyPhrase = ({ lang, text, children }) => (
-  <p className="block">
+  <span>
     {children}
     {lang ? <span className="text-gray-500">[{lang}]&nbsp;</span> : null}
     &ldquo;{text}&rdquo;
-  </p>
+  </span>
 )
 
 export default TinyPhrase

--- a/app/components/edit-status-buttons.jsx
+++ b/app/components/edit-status-buttons.jsx
@@ -1,0 +1,79 @@
+import { useQueryClient, useMutation } from '@tanstack/react-query'
+import supabase from 'lib/supabase-client'
+import { useCard } from 'app/data/hooks'
+import { toast } from 'react-hot-toast'
+
+const updateCardStatus = async ({ cardId, status }) => {
+  console.log(`update card status,`, cardId, status)
+  const { data, error } = await supabase
+    .from('user_card')
+    .update({
+      status,
+    })
+    .eq('id', cardId)
+    .select()
+  if (error) throw error
+  return data[0]
+}
+
+export default function EditCardStatusButtons({ cardId }) {
+  const queryClient = useQueryClient()
+  const { data: card } = useCard(cardId)
+  const updateStatus = useMutation({
+    // mutationFn: status => editExistingCard(status, card.id)
+    mutationFn: updateCardStatus,
+    onSuccess: data => {
+      toast.success(`Card successfully updated with status: "${data.status}"`)
+      queryClient.setQueryData(['card', cardId], data)
+    },
+  })
+  const isLearned = card?.status === 'learned'
+  const isActive = card?.status === 'active'
+  const isSkipped = card?.status === 'skipped'
+  return (
+    <>
+      <div className="flex flex-row mx-auto max-w-80 justify-center gap-4 mt-6">
+        <button
+          onClick={() => updateStatus.mutate({ cardId, status: 'learned' })}
+          className={`btn btn-success ${isLearned && 'btn-outline'}`}
+          disabled={updateStatus.isSubmitting || isLearned}
+        >
+          {isLearned ? 'Finished learning' : 'Mark complete'}
+        </button>
+        <button
+          onClick={() => updateStatus.mutate({ cardId, status: 'active' })}
+          className={`btn btn-info ${isActive && 'btn-outline'}`}
+          disabled={updateStatus.isSubmitting || isActive}
+        >
+          {isActive ? 'Actively learning' : 'Add to my deck'}
+        </button>
+        <button
+          onClick={() => updateStatus.mutate({ cardId, status: 'skipped' })}
+          className={`btn btn-warning ${isSkipped && 'btn-outline'}`}
+          disabled={updateStatus.isSubmitting || isSkipped}
+        >
+          Skip this card
+        </button>
+      </div>
+      <div className="text-center mx-auto text-sm text-base-content/70 my-2">
+        <p>
+          {isLearned && (
+            <>
+              You&apos;ve marked this card <code>&ldquo;learned&rdquo;</code>{' '}
+              (it won&apos;t show up in your daily reviews).
+            </>
+          )}
+          {isActive && <>This card is part of your active deck.</>}
+          {isSkipped && (
+            <>
+              You&apos;ve marked this card <code>&ldquo;skipped&rdquo;</code> so
+              you won&apos;t be asked to learn it.
+            </>
+          )}
+          <br />
+          Use these buttons to change card status.
+        </p>
+      </div>
+    </>
+  )
+}

--- a/app/data/hooks.ts
+++ b/app/data/hooks.ts
@@ -5,7 +5,7 @@ import { useRouter, usePathname } from 'next/navigation'
 import { getLanguageDetails, getPhraseDetails } from './fetchers'
 import supabase from 'lib/supabase-client'
 import type { Scalars, Maybe } from 'types/utils'
-import { Deck, DeckStub, Profile } from 'types/client-types'
+import { Deck, DeckStub, Profile, CardStub } from 'types/client-types'
 
 export type UseQueryResult = {
   status: string
@@ -15,6 +15,28 @@ export type UseQueryResult = {
   isSuccess: boolean
   isError: boolean
 }
+
+export const useCard = (
+  id: string
+): UseQueryResult & { data: Maybe<CardStub> } =>
+  useQuery({
+    queryKey: ['card', id],
+    queryFn: async ({ queryKey }) => {
+      const { data, error } = await supabase
+        .from('user_card')
+        .select('*')
+        .eq('id', queryKey[1])
+        .maybeSingle()
+      if (error) throw error
+      else return data
+    },
+    enabled: typeof id === 'string' && id.length > 0,
+    // retry: false,
+    staleTime: Infinity,
+    cacheTime: Infinity,
+    refetchOnMount: false,
+    refetchOnWindowFocus: false,
+  })
 
 export function useAllDecks(): UseQueryResult & { data: Array<DeckStub> } {
   return useQuery({

--- a/app/phrase/[id]/page.jsx
+++ b/app/phrase/[id]/page.jsx
@@ -1,6 +1,6 @@
 import Link from 'next/link'
 import { getAllPhraseDetails } from 'app/data/fetchers'
-import { TinyPhrase } from 'app/components/PhraseCardSmall'
+import TinyPhrase from 'app/components/TinyPhrase'
 import languages from 'lib/languages'
 
 export async function generateStaticParams() {

--- a/app/profile/avatar-edit.jsx
+++ b/app/profile/avatar-edit.jsx
@@ -2,7 +2,7 @@ import Image from 'next/image'
 import { useMutation } from '@tanstack/react-query'
 import supabase from 'lib/supabase-client'
 import ErrorList from 'app/components/ErrorList'
-import { toast } from 'react-toastify'
+import { toast } from 'react-hot-toast'
 
 const avatarFullUrl = fullPath =>
   `https://hepudeougzlgnuqvybrj.supabase.co/storage/v1/object/public/${fullPath}`

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,8 +17,7 @@
         "react-dom": "^18.3.1",
         "react-hot-toast": "^2.4.1",
         "react-modal": "^3.16.1",
-        "react-select": "^5.7.0",
-        "react-toastify": "^9.1.3"
+        "react-select": "^5.7.0"
       },
       "devDependencies": {
         "@tailwindcss/forms": "^0.5.3",
@@ -1708,15 +1707,6 @@
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
       "license": "MIT"
-    },
-    "node_modules/clsx": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
-      "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
     },
     "node_modules/color": {
       "version": "4.2.3",
@@ -4797,19 +4787,6 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
-      }
-    },
-    "node_modules/react-toastify": {
-      "version": "9.1.3",
-      "resolved": "https://registry.npmjs.org/react-toastify/-/react-toastify-9.1.3.tgz",
-      "integrity": "sha512-fPfb8ghtn/XMxw3LkxQBk3IyagNpF/LIKjOBflbexr2AWxAH1MJgvnESwEwBn9liLFXgTKWgBSdZpw9m4OTHTg==",
-      "license": "MIT",
-      "dependencies": {
-        "clsx": "^1.1.1"
-      },
-      "peerDependencies": {
-        "react": ">=16",
-        "react-dom": ">=16"
       }
     },
     "node_modules/react-transition-group": {

--- a/package.json
+++ b/package.json
@@ -26,8 +26,7 @@
     "react-dom": "^18.3.1",
     "react-hot-toast": "^2.4.1",
     "react-modal": "^3.16.1",
-    "react-select": "^5.7.0",
-    "react-toastify": "^9.1.3"
+    "react-select": "^5.7.0"
   },
   "devDependencies": {
     "@tailwindcss/forms": "^0.5.3",


### PR DESCRIPTION
This PR adds button to edit card status. This was a lot of work in and around the `BigPhrase` component, which was way too long and complex to begin with, so it also:
* Factors out TinyPhrase into its own component and file and ensures its use across the rest of the code base
* Cleans up the other mutation in BigPhrase (adding a new card to the deck from an existing phrase) and its status UI
* Manage cache invalidation a bit better -- this may be code that will be ripped out soon, but when Card is inferred from Phrase in some components, they won't update just from updating the Card cache; you need to also modify what's in the Phrase cache.
* Add a useCard hook that just fetches a single card with no joins (perhaps prep for this flat cache approach)