### PR TITLE
Improve the language home screen & introduce metadata via views

### DIFF
--- a/app/(app)/home/[lang]/page.jsx
+++ b/app/(app)/home/[lang]/page.jsx
@@ -18,6 +18,7 @@ const RecentReviewsSummary = ({ lang }) => {
 
   return (
     <div className="text-base-content bg-base-200 card-body">
+      <div className="card-title">Review flash cards</div>
       {countReviews > 5 &&
         `You've been studying ${countReviews > 40 && 'a lot'}!`}{' '}
       I see {countReviews} cards reviewed in the last week
@@ -34,6 +35,7 @@ const CardsSummary = ({ cards }) => {
   const beHappy = cardsLearned > 5
   return (
     <div className="text-base-content bg-base-200 card-body">
+      <div className="card-title">Manage your deck</div>
       You have:
       <ul className="ml-2 block">
         <li>🎴 {cardsInDeck} cards in your deck</li>
@@ -58,7 +60,7 @@ export default function Page({ params: { lang } }) {
 
   return (
     <>
-      <h1 className="text-2xl mt-6 mb-4">Learn {language}</h1>
+      <h1 className="text-4xl mt-6 mb-4">Learn {language}</h1>
       {data === null ? (
         <p>
           Are you sure you&apos;re learning this language? To create a deck and{' '}

--- a/app/(app)/home/[lang]/page.jsx
+++ b/app/(app)/home/[lang]/page.jsx
@@ -2,7 +2,7 @@
 
 import ErrorList from 'app/components/ErrorList'
 import { notFound } from 'next/navigation'
-import { useDeck } from 'app/data/hooks'
+import { useProfile } from 'app/data/hooks'
 import { useRecentReviews } from 'app/data/reviews'
 import Loading from 'app/loading'
 import languages from 'lib/languages'
@@ -20,7 +20,7 @@ const RecentReviewsSummary = ({ lang }) => {
     <div className="text-base-content bg-base-200 card-body">
       <div className="card-title">Review flash cards</div>
       {countReviews > 5 &&
-        `You've been studying ${countReviews > 40 && 'a lot'}!`}{' '}
+        `You've been studying ${countReviews > 40 ? 'a lot!' : ' – '}`}{' '}
       I see {countReviews} cards reviewed in the last week
       {countPositive > 0 && ` and you remembered ${countPositive} of them`}.
       Keep at it!
@@ -28,20 +28,19 @@ const RecentReviewsSummary = ({ lang }) => {
   )
 }
 
-const CardsSummary = ({ cards }) => {
-  const cardsInDeck = cards.active.length + cards.learned.length
-  const cardsActive = cards.active.length
-  const cardsLearned = cards.learned.length
-  const beHappy = cardsLearned > 5
+const CardsSummary = ({ deck }) => {
+  const { cards_active, cards_learned } = deck
+  const cardsInDeck = cards_active + cards_learned
+  const beHappy = cards_learned > 5
   return (
     <div className="text-base-content bg-base-200 card-body">
       <div className="card-title">Manage your deck</div>
       You have:
       <ul className="ml-2 block">
         <li>🎴 {cardsInDeck} cards in your deck</li>
-        <li>🤓 studying {cardsActive} currently</li>
+        <li>🤓 studying {cards_active} currently</li>
         <li>
-          🎊 and you&apos;ve learned {cardsLearned + ' '}
+          🎊 and you&apos;ve learned {cards_learned + ' '}
           of them{beHappy ? '!' : '.'}
         </li>
       </ul>
@@ -50,7 +49,8 @@ const CardsSummary = ({ cards }) => {
 }
 
 export default function Page({ params: { lang } }) {
-  const { data, error, status } = useDeck(lang)
+  const { data, error, status } = useProfile()
+  const deck = data?.deck_stubs?.find(d => d.lang === lang) || null
   if (status === 'loading') return <Loading />
   if (error) return <ErrorList error={error} />
 
@@ -86,7 +86,7 @@ export default function Page({ params: { lang } }) {
           <div className="w-100 md:w-1/2 p-4 grid gap-4">
             <div className="card w-96 glass">
               <figure>
-                <CardsSummary cards={data?.cards} />
+                <CardsSummary deck={deck} />
               </figure>
               <div className="card-body">
                 <Link href={`/my-decks/${lang}`} className="mx-auto btn">

--- a/app/(app)/home/page.jsx
+++ b/app/(app)/home/page.jsx
@@ -1,29 +1,93 @@
 'use client'
 
-import { useRouter } from 'next/navigation'
-import { useAllDecks } from 'app/data/hooks'
+import { useMemo } from 'react'
+import Link from 'next/link'
+import { useQuery } from '@tanstack/react-query'
+import { useProfile } from 'app/data/hooks'
 import languages from 'lib/languages'
+import supabase from 'lib/supabase-client'
+import Loading from 'app/loading'
+
+const collateArray = (data, key) => {
+  let result = {}
+  for (let i in data) {
+    let item = data[i]
+    let itemKey = item[key]
+    if (Array.isArray(result[itemKey])) result[itemKey].push(item)
+    else result[itemKey] = [item]
+  }
+  return result
+}
+
+const useRecentReviewActivity = () => {
+  return useQuery({
+    queryKey: ['all-reviews'],
+    queryFn: async () => {
+      const { data, error } = await supabase
+        .from('user_card_review_plus')
+        .select('*')
+        .order('created_at', { ascending: false })
+      if (error) throw error
+
+      const result = collateArray(data, 'lang')
+      console.log(`The collated array`, result)
+
+      return {
+        list: data,
+        collated: result,
+        keysInOrder: Object.keys(result),
+      }
+    },
+  })
+}
 
 export default function Page() {
-  const { data } = useAllDecks()
-  const router = useRouter()
+  const { data: profile, isLoading } = useProfile()
+  const { data: reviews, error } = useRecentReviewActivity()
 
-  return (
-    <div className="form-control max-w-sm">
+  console.log(`This is the profile and reviews objects`, profile, reviews)
+  const remainingDecks = useMemo(() => {
+    if (!profile?.deck_stubs?.length) return null
+    return profile.deck_stubs
+      .filter(d => !reviews?.keysInOrder?.includes(d.lang) ?? false)
+      .sort((left, right) => {
+        // the deck that was updated more recently sorts first
+        return left?.updated_at === right?.updated_at
+          ? 0
+          : left?.updated_at > right?.updated_at
+          ? -1
+          : 1
+      })
+      .map(d => d.lang)
+  }, [profile, reviews])
+
+  return isLoading ? (
+    <Loading />
+  ) : (
+    <div className="form-control max-w-sm flex flex-col gap-4">
       <label className="label h2">
         Which language are you working on today?
       </label>
-      <select
-        onChange={event => router.push(`/home/${event.target.value}`)}
-        className="select select-secondary text-base-content text-xl h-12"
-      >
-        <option>-- select a deck to work on --</option>
-        {data?.map(deck => (
-          <option key={deck.lang} value={deck.lang}>
-            {languages[deck.lang]}
-          </option>
+      {reviews?.keysInOrder?.map(lang => (
+        <div key={lang} className="hover:glass p-2 rounded">
+          <Link href={`home/${lang}`}>
+            <p className="text-xl">{languages[lang]}</p>
+            <p>{reviews?.collated[lang].length} reviews</p>
+            <p>
+              Last reviewed on{' '}
+              {reviews?.collated[lang][0]?.created_at?.split('T')[0]}
+            </p>
+          </Link>
+        </div>
+      ))}
+      <p className="my-4">Or start your first review for these:</p>
+      <ol>
+        {remainingDecks?.map(lang => (
+          <li key={lang} className="hover:link my-2">
+            <Link href={`/home/${lang}`}>{languages[lang]}</Link>
+          </li>
         ))}
-      </select>
+      </ol>
     </div>
   )
 }

--- a/app/(app)/home/page.jsx
+++ b/app/(app)/home/page.jsx
@@ -17,6 +17,7 @@ export default function Page() {
         onChange={event => router.push(`/home/${event.target.value}`)}
         className="select select-secondary text-base-content text-xl h-12"
       >
+        <option>-- select a deck to work on --</option>
         {data?.map(deck => (
           <option key={deck.lang} value={deck.lang}>
             {languages[deck.lang]}

--- a/app/(app)/home/page.jsx
+++ b/app/(app)/home/page.jsx
@@ -44,6 +44,7 @@ const useRecentReviewActivity = () => {
 export default function Page() {
   const { data: profile, isLoading } = useProfile()
   const { data: reviews, error } = useRecentReviewActivity()
+  const activeDecks = reviews?.keysInOrder
 
   console.log(`This is the profile and reviews objects`, profile, reviews)
   const remainingDecks = useMemo(() => {
@@ -64,30 +65,20 @@ export default function Page() {
   return isLoading ? (
     <Loading />
   ) : (
-    <div className="form-control max-w-sm flex flex-col gap-4">
-      <label className="label h2">
-        Which language are you working on today?
-      </label>
-      {reviews?.keysInOrder?.map(lang => (
-        <div key={lang} className="hover:glass p-2 rounded">
+    <div className="form-control max-w-sm flex flex-col gap-4 p-2">
+      <label className="label h2 text-center">Continue learning...</label>
+      {[...activeDecks, ...remainingDecks]?.map(lang => (
+        <div key={lang} className="glass p-2 rounded text-center">
           <Link href={`home/${lang}`}>
-            <p className="text-xl">{languages[lang]}</p>
-            <p>{reviews?.collated[lang].length} reviews</p>
-            <p>
-              Last reviewed on{' '}
-              {reviews?.collated[lang][0]?.created_at?.split('T')[0]}
-            </p>
+            <p className="text-xl py-2">{languages[lang]}</p>
           </Link>
         </div>
       ))}
-      <p className="my-4">Or start your first review for these:</p>
-      <ol>
-        {remainingDecks?.map(lang => (
-          <li key={lang} className="hover:link my-2">
-            <Link href={`/home/${lang}`}>{languages[lang]}</Link>
-          </li>
-        ))}
-      </ol>
+      <div className="mx-auto">
+        <Link href={`/my-decks/new`}>
+          <span className="btn btn-ghost">+ Start a new language</span>
+        </Link>
+      </div>
     </div>
   )
 }

--- a/app/(app)/home/page.jsx
+++ b/app/(app)/home/page.jsx
@@ -2,44 +2,9 @@
 
 import { useMemo } from 'react'
 import Link from 'next/link'
-import { useQuery } from '@tanstack/react-query'
-import { useProfile } from 'app/data/hooks'
+import { useProfile, useRecentReviewActivity } from 'app/data/hooks'
 import languages from 'lib/languages'
-import supabase from 'lib/supabase-client'
 import Loading from 'app/loading'
-
-const collateArray = (data, key) => {
-  let result = {}
-  for (let i in data) {
-    let item = data[i]
-    let itemKey = item[key]
-    if (Array.isArray(result[itemKey])) result[itemKey].push(item)
-    else result[itemKey] = [item]
-  }
-  return result
-}
-
-const useRecentReviewActivity = () => {
-  return useQuery({
-    queryKey: ['all-reviews'],
-    queryFn: async () => {
-      const { data, error } = await supabase
-        .from('user_card_review_plus')
-        .select('*')
-        .order('created_at', { ascending: false })
-      if (error) throw error
-
-      const result = collateArray(data, 'lang')
-      console.log(`The collated array`, result)
-
-      return {
-        list: data,
-        collated: result,
-        keysInOrder: Object.keys(result),
-      }
-    },
-  })
-}
 
 export default function Page() {
   const { data: profile, isLoading } = useProfile()

--- a/app/(app)/home/page.jsx
+++ b/app/(app)/home/page.jsx
@@ -44,7 +44,7 @@ const useRecentReviewActivity = () => {
 export default function Page() {
   const { data: profile, isLoading } = useProfile()
   const { data: reviews, error } = useRecentReviewActivity()
-  const activeDecks = reviews?.keysInOrder
+  const activeDecks = reviews?.keysInOrder ?? []
 
   console.log(`This is the profile and reviews objects`, profile, reviews)
   const remainingDecks = useMemo(() => {

--- a/app/(app)/my-decks/ClientPage.jsx
+++ b/app/(app)/my-decks/ClientPage.jsx
@@ -1,7 +1,7 @@
 'use client'
 
 import Link from 'next/link'
-import { useAllDecks } from 'app/data/hooks'
+import { useProfile } from 'app/data/hooks'
 import Loading from 'app/loading'
 import languages from 'lib/languages'
 import ErrorList from 'app/components/ErrorList'
@@ -15,27 +15,28 @@ function OneDeck({ deck }) {
       <h2 className="h2">{languages[deck.lang]}</h2>
       <p>
         You&apos;re learning {languages[deck.lang]}! There are{' '}
-        {deck.cards.length} cards in your deck.
+        {deck.cards_active} cards in your deck.
       </p>
     </Link>
   )
 }
 
 export default function ClientPage() {
-  const { status, data, error } = useAllDecks()
+  const { status, data, error } = useProfile()
   if (status === 'loading') return <Loading />
-
   if (status === 'error') return <ErrorList error={error} />
+
+  const decks = data?.deck_stubs
 
   return (
     <>
-      {data.length ? (
+      {decks.length ? (
         <>
           <p>
-            You have {data.length} active decks. Which one would you like to
+            You have {decks.length} active decks. Which one would you like to
             work on today?
           </p>
-          {data?.map(deck => (
+          {decks?.map(deck => (
             <OneDeck key={deck.lang} deck={deck} />
           ))}
         </>

--- a/app/(app)/my-decks/[lang]/new-card/form.jsx
+++ b/app/(app)/my-decks/[lang]/new-card/form.jsx
@@ -46,11 +46,7 @@ const SelectLanguageYouKnow = ({ onChange, disabledLang }) => {
   )
 }
 
-export default function AddCardPhraseForm({
-  lang,
-  offerRefresh = false,
-  cancel,
-}) {
+export default function AddCardPhraseForm({ lang, cancel }) {
   const { status, data: deck } = useDeck(lang)
   const [selectLang, setSelectLang] = useState()
   const queryClient = useQueryClient()
@@ -59,11 +55,11 @@ export default function AddCardPhraseForm({
 
   const addCardPhrase = useMutation({
     mutationFn: postNewPhraseCardTranslations,
-    onSuccess: data => {
+    onSuccess: () => {
       // console.log(`postNewPhraseCardTranslations success`, data)
       // toast.success(t => <Success />)
       queryClient.invalidateQueries({ queryKey: ['user_deck', lang] })
-      queryClient.invalidateQueries({ queryKey: ['user_decks'] })
+      queryClient.invalidateQueries({ queryKey: ['user_profile'] })
       // deck stubs don't need to be updated here
     },
     onError: error => {

--- a/app/(app)/my-decks/[lang]/new-card/form.jsx
+++ b/app/(app)/my-decks/[lang]/new-card/form.jsx
@@ -64,6 +64,7 @@ export default function AddCardPhraseForm({
       // toast.success(t => <Success />)
       queryClient.invalidateQueries({ queryKey: ['user_deck', lang] })
       queryClient.invalidateQueries({ queryKey: ['user_decks'] })
+      // deck stubs don't need to be updated here
     },
     onError: error => {
       throw error

--- a/app/(app)/my-decks/new/form.jsx
+++ b/app/(app)/my-decks/new/form.jsx
@@ -5,7 +5,7 @@ import { useMutation, useQueryClient } from '@tanstack/react-query'
 import Select from 'react-select'
 import { toast } from 'react-hot-toast'
 import { useRouter } from 'next/navigation'
-import { useAllDecks } from 'app/data/hooks'
+import { useProfile } from 'app/data/hooks'
 import ErrorList from 'app/components/ErrorList'
 import languages, { allLanguageOptions } from 'lib/languages'
 import { postNewDeck } from './add-new-deck'
@@ -26,13 +26,15 @@ export default function Form() {
     },
     onSuccess: data => {
       // console.log(`onSuccess data,`, data)
+      queryClient.invalidateQueries({ queryKey: ['all-deck-stubs'] })
       queryClient.invalidateQueries({ queryKey: ['user_decks'] })
       toast.success(`Created a new deck to learn ${languages[data.lang]}`)
       router.push(`/my-decks/${data.lang}`)
     },
   })
 
-  const { data, error, status } = useAllDecks()
+  const { data, error, status } = useProfile()
+  const decks = data?.deck_stubs
 
   return (
     <div>
@@ -45,7 +47,7 @@ export default function Form() {
         <Select
           options={allLanguageOptions}
           isOptionDisabled={option =>
-            data?.some(deck => {
+            decks?.some(deck => {
               return status === 'loading'
                 ? // while loading the list of decks, all options enabled
                   false

--- a/app/(app)/my-decks/new/form.jsx
+++ b/app/(app)/my-decks/new/form.jsx
@@ -26,8 +26,7 @@ export default function Form() {
     },
     onSuccess: data => {
       // console.log(`onSuccess data,`, data)
-      queryClient.invalidateQueries({ queryKey: ['all-deck-stubs'] })
-      queryClient.invalidateQueries({ queryKey: ['user_decks'] })
+      queryClient.invalidateQueries({ queryKey: ['user_profile'] })
       toast.success(`Created a new deck to learn ${languages[data.lang]}`)
       router.push(`/my-decks/${data.lang}`)
     },

--- a/app/(app)/review/[lang]/card.jsx
+++ b/app/(app)/review/[lang]/card.jsx
@@ -9,10 +9,18 @@ import { toast } from 'react-hot-toast'
 
 const postReview = async ({ card_id, score, prevId }) => {
   if (!card_id || !score) throw Error('Invalid review; cannot log')
+  const id = prevId ? { id: prevId } : {}
+  const submitData = {
+    score,
+    card_id,
+    ...id,
+  }
+
+  // console.log(`About to post the review,`, submitData, prevId)
 
   const { data, error } = await supabase
     .from('user_card_review')
-    .upsert({ score, card_id, id: prevId })
+    .upsert(submitData)
     .select()
 
   if (error) throw Error(error)

--- a/app/(app)/review/[lang]/card.jsx
+++ b/app/(app)/review/[lang]/card.jsx
@@ -20,7 +20,7 @@ const postReview = async ({ card_id, score, prevId }) => {
   return data[0]
 }
 
-export default function CardInner({ card, advance, addReview, hidden }) {
+export default function CardInner({ card, nextCard, addReview, hidden }) {
   const [isRevealed, setIsRevealed] = useState(false)
   const reveal = () => {
     setIsRevealed(true)
@@ -40,7 +40,7 @@ export default function CardInner({ card, advance, addReview, hidden }) {
         toast('got it', { icon: '👍️', position: 'bottom-center' })
       if (result.score === 2)
         toast.success('got it', { position: 'bottom-center' })
-      setTimeout(advance, 2000)
+      setTimeout(nextCard, 1500)
     },
   })
 

--- a/app/(app)/review/[lang]/client.jsx
+++ b/app/(app)/review/[lang]/client.jsx
@@ -36,8 +36,11 @@ export default function ClientPage({ lang }) {
 
   const canBackup = cardIndex > 0
   const canAdvance = cardIndex < reviewCards.length - 1
-  const gobackaCard = () => setCardIndex(cardIndex - 1)
-  const advanceCard = () => setCardIndex(cardIndex + 1)
+  const gobackaCard = () => setCardIndex(i => i - 1)
+  const advanceCard = () => setCardIndex(i => i + 1)
+  // This is different from advanceCard because it only wants to move forward
+  // by 1 after submitting a review, not to stack with button-clicks.
+  const nextCard = () => setCardIndex(cardIndex + 1)
 
   const addReview = review => {
     const index = reviews.findIndex(r => r.id === review.id)
@@ -86,7 +89,7 @@ export default function ClientPage({ lang }) {
         <CardInner
           key={c.id}
           card={c}
-          advance={advanceCard}
+          nextCard={nextCard}
           addReview={addReview}
           hidden={c.id !== reviewCards[cardIndex]?.id}
         />

--- a/app/components/Sidebar.jsx
+++ b/app/components/Sidebar.jsx
@@ -5,7 +5,7 @@ import Link from 'next/link'
 import Garlic from 'app/components/Garlic'
 import languages from 'lib/languages'
 import { usePathname, useRouter } from 'next/navigation'
-import { useProfile, useAllDecks } from 'app/data/hooks'
+import { useProfile } from 'app/data/hooks'
 import Loading from 'app/loading'
 import ErrorList from './ErrorList'
 import supabase from 'lib/supabase-client'
@@ -71,14 +71,15 @@ const GenericMenu = ({ menu }) => {
 const StaticMenu = () => <GenericMenu menu={staticMenu} />
 
 const DeckMenu = () => {
-  const { data, status, error } = useAllDecks()
+  const { data, status, error } = useProfile()
   if (status === 'loading') return null
   if (error) return <ErrorList error={error.message} />
 
+  const decks = data?.deck_stubs
   const menuData = {
     name: 'Learning decks',
     href: '/home',
-    links: data?.map(deck => {
+    links: decks?.map(deck => {
       return {
         name: languages[deck.lang],
         href: `/home/${deck.lang}`,

--- a/app/data/fetchers.ts
+++ b/app/data/fetchers.ts
@@ -75,13 +75,3 @@ export const getPhraseDetails = async (
   // console.log(`getPhraseDetails data`, data.phrase_to, data.phrase_from)
   return phrasePostFetch(data)
 }
-
-export const getProfile = async (): Promise<Profile> => {
-  const { data, error } = await supabase
-    .from('user_profile')
-    .select(`*, user_decks:user_deck(id, lang)`)
-    .maybeSingle()
-  if (error) console.log(`getProfile`, error)
-
-  return data
-}

--- a/app/data/hooks.ts
+++ b/app/data/hooks.ts
@@ -5,7 +5,15 @@ import { useRouter, usePathname } from 'next/navigation'
 import { getLanguageDetails, getPhraseDetails } from './fetchers'
 import supabase from 'lib/supabase-client'
 import type { Scalars, Maybe } from 'types/utils'
-import { Deck, DeckPlus, Profile, CardStub } from 'types/client-types'
+import {
+  Deck,
+  DeckPlus,
+  Profile,
+  CardStub,
+  ReviewsCollated,
+  Phrase,
+  Language,
+} from 'types/client-types'
 import { useAuth } from 'lib/auth-context'
 
 export type UseQueryResult = {
@@ -18,8 +26,8 @@ export type UseQueryResult = {
 }
 
 export const useCard = (
-  id: string
-): UseQueryResult & { data: Maybe<CardStub> } =>
+  id: Scalars['UUID']
+): UseQueryResult & { data?: CardStub } =>
   useQuery({
     queryKey: ['card', id],
     queryFn: async ({ queryKey }) => {
@@ -39,7 +47,9 @@ export const useCard = (
     refetchOnWindowFocus: false,
   })
 
-export function useLanguageDetails(lang: string): UseQueryResult {
+export function useLanguageDetails(
+  lang: string
+): UseQueryResult & { data?: Language } {
   return useQuery({
     queryKey: ['phrases', 'lang', lang],
     queryFn: async () => getLanguageDetails(lang),
@@ -85,7 +95,7 @@ const fetchDeck = async (lang: string): Promise<Deck> => {
   return deck
 }
 
-export function useDeck(deckLang: string): UseQueryResult {
+export function useDeck(deckLang: string): UseQueryResult & { data?: Deck } {
   return useQuery({
     queryKey: ['user_deck', deckLang],
     queryFn: ({ queryKey }) => fetchDeck(queryKey[1]),
@@ -98,7 +108,9 @@ export function useDeck(deckLang: string): UseQueryResult {
   })
 }
 
-export function usePhrase(id: Scalars['UUID']): UseQueryResult {
+export function usePhrase(
+  id: Scalars['UUID']
+): UseQueryResult & { data?: Phrase } {
   return useQuery({
     queryKey: ['phrase', id],
     queryFn: async ({ queryKey }) => getPhraseDetails(queryKey[1]),

--- a/app/data/hooks.ts
+++ b/app/data/hooks.ts
@@ -166,3 +166,38 @@ export function useProfile(): UseQueryResult & { data?: Profile } {
     enabled: router && pathname && userId ? true : false,
   })
 }
+
+const collateArray = (data: Array<Object>, key: string): Object => {
+  let result = {}
+  for (let i in data) {
+    let item = data[i]
+    let itemKey = item[key]
+    if (Array.isArray(result[itemKey])) result[itemKey].push(item)
+    else result[itemKey] = [item]
+  }
+  return result
+}
+
+export const useRecentReviewActivity = (): UseQueryResult & {
+  data?: ReviewsCollated
+} => {
+  return useQuery({
+    queryKey: ['all-reviews'],
+    queryFn: async () => {
+      const { data, error } = await supabase
+        .from('user_card_review_plus')
+        .select('*')
+        .order('created_at', { ascending: false })
+      if (error) throw error
+
+      const result = collateArray(data, 'lang')
+      console.log(`The collated array`, result)
+
+      return {
+        list: data,
+        collated: result,
+        keysInOrder: Object.keys(result),
+      }
+    },
+  })
+}

--- a/app/data/hooks.ts
+++ b/app/data/hooks.ts
@@ -76,9 +76,9 @@ const fetchDeck = async (lang: string): Promise<Deck> => {
     lang: data?.lang,
     all_phrase_ids: rawCards.map(card => card.phrase_id),
     cards: {
-      active: rawCards.filter(card => card.status === 'active'),
-      learned: rawCards.filter(card => card.status === 'learned'),
-      skipped: rawCards.filter(card => card.status === 'skipped'),
+      active: rawCards.filter(({ status }) => status === 'active'),
+      learned: rawCards.filter(({ status }) => status === 'learned'),
+      skipped: rawCards.filter(({ status }) => status === 'skipped'),
     },
   }
 

--- a/app/getting-started/page.jsx
+++ b/app/getting-started/page.jsx
@@ -129,7 +129,7 @@ export default function Page() {
         <CreateFirstDeckStep value={tempDeckToAdd} set={setTempDeckToAdd} />
 
         {tempLanguagePrimaryToUse &&
-        (tempDeckToAdd || profile.user_decks?.length > 0) &&
+        (tempDeckToAdd || profile.deck_stubs?.length > 0) &&
         tempUsernameToUse ? (
           <div className="my-6 flex flex-row-reverse justify-around items-center">
             <button
@@ -211,7 +211,7 @@ const SetPrimaryLanguageStep = ({ value, set }) => {
 
 const CreateFirstDeckStep = ({ value, set }) => {
   const { data } = useProfile()
-  const decks = data?.user_decks || []
+  const decks = data?.deck_stubs || []
   const [closed, setClosed] = useState(true)
   return closed && decks?.length ? (
     <Completed>

--- a/app/profile/change-email/form.jsx
+++ b/app/profile/change-email/form.jsx
@@ -7,7 +7,7 @@ import ErrorList from 'app/components/ErrorList'
 import { BASE_URL } from 'lib/helpers'
 
 export default function SetNewEmailForm() {
-  const { user } = useAuth()
+  const { userEmail } = useAuth()
 
   const changeEmail = useMutation({
     mutationFn: async event => {
@@ -34,7 +34,7 @@ export default function SetNewEmailForm() {
           <form role="form" onSubmit={changeEmail.mutate} className="form">
             <fieldset
               className="flex flex-col gap-y-4"
-              disabled={!user || changeEmail.isSubmitting}
+              disabled={!userEmail || changeEmail.isSubmitting}
             >
               <div>
                 <p>
@@ -53,7 +53,7 @@ export default function SetNewEmailForm() {
                   tabIndex="1"
                   type="text"
                   placeholder="email@domain"
-                  defaultValue={user ? user.email : null}
+                  defaultValue={userEmail}
                 />
               </div>
               <div className="flex flex-row justify-between">
@@ -61,7 +61,7 @@ export default function SetNewEmailForm() {
                   tabIndex="3"
                   className="btn btn-primary"
                   type="submit"
-                  disabled={!user || changeEmail.isSubmitting}
+                  disabled={!userEmail || changeEmail.isSubmitting}
                   aria-disabled={changeEmail.isSubmitting}
                 >
                   Set new Email

--- a/app/profile/client.jsx
+++ b/app/profile/client.jsx
@@ -154,7 +154,7 @@ export const ProfileCard = () => {
 }
 
 export const UserAuthCard = () => {
-  const { user } = useAuth()
+  const { userEmail } = useAuth()
   return (
     <div className="big-card flex flex-col space-y-4">
       <h2 className="h3">Login credentials</h2>
@@ -164,7 +164,7 @@ export const UserAuthCard = () => {
           <input
             type="text"
             className="border rounded p-3 flex-grow"
-            value={user?.email ?? 'loading...'}
+            value={userEmail ?? 'loading...'}
             disabled
           />
           <Link href="/profile/change-email" className="btn btn-ghost">

--- a/lib/auth-context.js
+++ b/lib/auth-context.js
@@ -57,7 +57,7 @@ export function AuthProvider({ children }) {
     return () => {
       listener.subscription.unsubscribe()
     }
-  }, [queryClient, userId, userEmail])
+  }, [queryClient, userId])
 
   const value = {
     isAuth,

--- a/lib/auth-context.js
+++ b/lib/auth-context.js
@@ -38,12 +38,10 @@ export function AuthProvider({ children }) {
           setUserId(null)
           setUserEmail(null)
           queryClient.removeQueries({ queryKey: ['user_profile'] })
-          queryClient.removeQueries({ queryKey: ['user_decks'] })
           queryClient.removeQueries({ queryKey: ['user_deck'] })
         } else {
           if (session?.user.id !== userId) {
             queryClient.invalidateQueries({ queryKey: ['user_profile'] })
-            queryClient.invalidateQueries({ queryKey: ['user_decks'] })
             queryClient.invalidateQueries({ queryKey: ['user_deck'] })
           }
 

--- a/lib/auth-context.js
+++ b/lib/auth-context.js
@@ -11,17 +11,20 @@ import supabase from 'lib/supabase-client'
 */
 
 const blank = {
-  // user: null,
   isAuth: false,
+  userId: null,
+  userEmail: null,
 }
 
 const AuthContext = createContext(blank)
 
 export function AuthProvider({ children }) {
-  const [user, setUser] = useState(null)
-  const userId = user?.id ?? null
+  const [isAuth, setIsAuth] = useState(false)
+  const [userId, setUserId] = useState()
+  const [userEmail, setUserEmail] = useState()
 
   const queryClient = useQueryClient()
+
   useEffect(() => {
     if (!queryClient) {
       console.log('Returning early bc queryClient hook has not come back')
@@ -31,7 +34,9 @@ export function AuthProvider({ children }) {
       (event, session) => {
         console.log(`Auth state changed: ${event}`, session)
         if (event === 'SIGNED_OUT') {
-          setUser(null)
+          setIsAuth(false)
+          setUserId(null)
+          setUserEmail(null)
           queryClient.removeQueries({ queryKey: ['user_profile'] })
           queryClient.removeQueries({ queryKey: ['user_decks'] })
           queryClient.removeQueries({ queryKey: ['user_deck'] })
@@ -41,7 +46,10 @@ export function AuthProvider({ children }) {
             queryClient.invalidateQueries({ queryKey: ['user_decks'] })
             queryClient.invalidateQueries({ queryKey: ['user_deck'] })
           }
-          setUser(session?.user ?? null)
+
+          setIsAuth(session?.user?.role === 'authenticated')
+          setUserId(session?.user?.id)
+          setUserEmail(session?.user?.email)
         }
       }
     )
@@ -49,12 +57,12 @@ export function AuthProvider({ children }) {
     return () => {
       listener.subscription.unsubscribe()
     }
-  }, [queryClient, userId])
+  }, [queryClient, userId, userEmail])
 
   const value = {
-    user,
-    isAuth: user?.role === 'authenticated',
+    isAuth,
     userId,
+    userEmail,
   }
 
   // console.log(`Rendering AuthContext.Provider`, value)
@@ -62,8 +70,7 @@ export function AuthProvider({ children }) {
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>
 }
 
-// a hook to use whenever we need to consume data from `AuthProvider`.
-// So, We don't need React.useContext everywhere we need data from AuthContext.
+// A for whenever we need to access the auth context
 
 export function useAuth() {
   const context = useContext(AuthContext)

--- a/supabase/views.sql
+++ b/supabase/views.sql
@@ -1,0 +1,18 @@
+CREATE OR REPLACE VIEW
+
+  public.user_card_review_plus 
+
+ WITH (security_invoker=on)
+
+  AS (
+    SELECT
+      r.id,
+      r.created_at,
+      r.card_id,
+      r.score,
+      d.lang
+    FROM
+      public.user_card_review AS r
+      JOIN public.user_card AS c ON (r.card_id = c.id)
+      JOIN public.user_deck AS d ON (c.user_deck_id = d.id)
+  );

--- a/supabase/views/user_card_review_plus.sql
+++ b/supabase/views/user_card_review_plus.sql
@@ -16,3 +16,4 @@ CREATE OR REPLACE VIEW
       JOIN public.user_card AS c ON (r.card_id = c.id)
       JOIN public.user_deck AS d ON (c.user_deck_id = d.id)
   );
+

--- a/supabase/views/user_deck_plus.sql
+++ b/supabase/views/user_deck_plus.sql
@@ -1,0 +1,31 @@
+CREATE OR REPLACE VIEW
+  public.user_deck_plus
+
+ WITH (security_invoker=on)
+
+  AS (
+    WITH first_step AS (SELECT
+      d.id,
+      d.uid,
+      d.lang,
+      d.created_at,
+      COUNT(*) FILTER (WHERE c.status = 'learned') AS cards_learned,
+      COUNT(*) FILTER (WHERE c.status = 'active') AS cards_active,
+      COUNT(*) FILTER (WHERE c.status = 'skipped') AS cards_skipped,
+      (SELECT COUNT(*) FROM public.phrase AS p WHERE p.lang = d.lang) AS lang_total_phrases,
+      (SELECT MAX(updated_at) FROM public.user_card_review_plus AS r WHERE r.lang = d.lang LIMIT 1) AS most_recent_review_at
+    FROM
+      public.user_deck AS d
+      JOIN public.user_card AS c ON (d.id = c.user_deck_id)
+    GROUP BY d.id, d.lang, d.created_at
+    )
+    SELECT
+      *,
+      CASE
+        WHEN most_recent_review_at > created_at
+        THEN most_recent_review_at
+        ELSE created_at
+      END AS most_recent_activity_at
+      FROM first_step
+      ORDER BY most_recent_activity_at
+  );

--- a/types/client-types.ts
+++ b/types/client-types.ts
@@ -72,3 +72,17 @@ export type Deck = DeckStub & {
     skipped: any[]
   }
 }
+
+export type Review = {
+  id: Scalars['UUID']
+  created_at: string
+  card_id: Scalars['UUID']
+  score: number
+  lang: string
+}
+
+export type ReviewsCollated = {
+  list: Array<Review>
+  collated: Object
+  keysInOrder: Array<string>
+}

--- a/types/client-types.ts
+++ b/types/client-types.ts
@@ -32,6 +32,14 @@ export type DeckStub = {
   lang: string
 }
 
+export type DeckPlus = DeckStub & {
+  cards_learned: number
+  cards_active: number
+  cards_skipped: number
+  lang_total_phrases: number | null
+  most_recent_review: string | null
+}
+
 type LanguageStub = {
   lang: string
   name: string

--- a/types/client-types.ts
+++ b/types/client-types.ts
@@ -28,6 +28,7 @@ export type CardStub = {
 
 export type DeckStub = {
   id: Scalars['UUID']
+  created_at?: string
   lang: string
 }
 
@@ -47,7 +48,7 @@ export type Profile = {
   avatar_url: string
   languages_spoken: Array<string>
   language_primary: string
-  user_deck?: Array<DeckStub>
+  deck_stubs: Array<DeckStub>
 }
 
 // count_all: number


### PR DESCRIPTION
This PR introduces a new way of collating summary data, makes several improvements and simplifications to the `home/[lang]` and `my-decks/[lang]` pages, and retires the useAllDecks hook which was sitting in a weird in-between place (between "get a summary of _all_ decks" and "get the details of _one_ deck") and is now replaced in all instances with the `deck_stubs` property on the data returned by `useProfile`. 

We are now able to remove a lot of the javascript that loops over, counts, sorts and filters the returned cards to present info to the user, such as how many cards they have with each status in their deck, or the timestamp of their most recent review in that language. It is much easier to read, write and maintain this functionality in SQL than in Javascript, so I'm looking forward to using this pattern in the future, but it does add a bit more pressure to the need to get migrations working for this project. (Currently the views are located in `supabase/views` but they only exist in the database if you copy/paste them in there.)

Specifically:
1. We add a view in the postgres database called `user_deck_plus` which includes a few extra fields: the total number of cards for each status, the time of the most recent review, the total number of phrases available in that language.
1. Alters useProfile to fetch from this new "plus" view; instead of using useAllDecks we use useProfile, and select data.deck_stubs to get the array of decks available and their summary data.
1. Remove a lot of the logic of filtering/sorting/counting deck cards in the react app, preferring the data fetched from the postgres view.
1. Add a new query key for `['all-reviews']` which uses a different naming style signaling a shift toward a new data strategy where we'll do more heavy "collating" of the data before caching it. This all-reviews cache key refers to an object which contains the raw list of all reviews, plus a collated set of lists for each language/deck, and an ordered array showing the recency of each deck's use (which is helping in a number of front-end situations, e.g. ordering the options for which deck to work on today)
1. Refactors the AuthContext to avoid storing objects to make it easier for react to recognize no-op updates and avoid re-rendering
1. Refactors the "next" and "prev" buttons in the review interface, the first time in this app using a function as the input for `setSomeState` calls so it updates the pending state rather than previous state. This way fast-clicking on the next and previous buttons will work correctly even if the clicks come more quickly than the app can re-render.