### PR TITLE
Feature: make the site "exportable"

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -4,5 +4,6 @@
   "rules": {
     "react-hooks/rules-of-hooks": "error",
     "react-hooks/exhaustive-deps": "warn"
-  }
+  },
+  "ignorePatterns": ["out/**/*"]
 }

--- a/.prettierignore
+++ b/.prettierignore
@@ -3,3 +3,4 @@ node_modules
 tsconfig.json
 supabase/.temp
 types/supabase.ts
+out

--- a/app/(app)/home/[lang]/client.jsx
+++ b/app/(app)/home/[lang]/client.jsx
@@ -1,0 +1,101 @@
+'use client'
+
+import ErrorList from 'app/components/ErrorList'
+import { notFound } from 'next/navigation'
+import { useProfile } from 'app/data/hooks'
+import { useRecentReviews } from 'app/data/reviews'
+import Loading from 'app/loading'
+import languages from 'lib/languages'
+import Link from 'next/link'
+
+const RecentReviewsSummary = ({ lang }) => {
+  const { data, error, status } = useRecentReviews(lang)
+  if (status === 'loading') return <Loading />
+  if (error) return <ErrorList error={error} />
+
+  const countReviews = data?.length
+  const countPositive = data?.filter(r => r.score > 0).length
+
+  return (
+    <div className="text-base-content bg-base-200 card-body">
+      <div className="card-title">Review flash cards</div>
+      {countReviews > 5 &&
+        `You've been studying ${countReviews > 40 ? 'a lot!' : ' – '}`}{' '}
+      I see {countReviews} cards reviewed in the last week
+      {countPositive > 0 && ` and you remembered ${countPositive} of them`}.
+      Keep at it!
+    </div>
+  )
+}
+
+const CardsSummary = ({ deck }) => {
+  const { cards_active, cards_learned } = deck
+  const cardsInDeck = cards_active + cards_learned
+  const beHappy = cards_learned > 5
+  return (
+    <div className="text-base-content bg-base-200 card-body">
+      <div className="card-title">Manage your deck</div>
+      You have:
+      <ul className="ml-2 block">
+        <li>🎴 {cardsInDeck} cards in your deck</li>
+        <li>🤓 studying {cards_active} currently</li>
+        <li>
+          🎊 and you&apos;ve learned {cards_learned + ' '}
+          of them{beHappy ? '!' : '.'}
+        </li>
+      </ul>
+    </div>
+  )
+}
+
+export default function Client({ lang }) {
+  const { data, error, status } = useProfile()
+  const deck = data?.deck_stubs?.find(d => d.lang === lang) || null
+  if (status === 'loading') return <Loading />
+  if (error) return <ErrorList error={error} />
+
+  // the long name
+  const language = languages[lang]
+  if (typeof language !== 'string') notFound()
+
+  return (
+    <>
+      {data === null ? (
+        <p>
+          Are you sure you&apos;re learning this language? To create a deck and{' '}
+          <Link className="underline" href="/my-decks/new">
+            start learning {language}, click here
+          </Link>
+          .
+        </p>
+      ) : (
+        <div>
+          <div className="md:w-1/2 p-4 grid gap-4">
+            <div className="card w-96 glass">
+              <figure>
+                <RecentReviewsSummary lang={lang} />
+              </figure>
+              <div className="card-body">
+                <Link href={`/review/${lang}`} className="mx-auto btn">
+                  Start a review session
+                </Link>
+              </div>
+            </div>
+          </div>
+          <div className="w-100 md:w-1/2 p-4 grid gap-4">
+            <div className="card w-96 glass">
+              <figure>
+                <CardsSummary deck={deck} />
+              </figure>
+              <div className="card-body">
+                <Link href={`/my-decks/${lang}`} className="mx-auto btn">
+                  Browse/manage on your deck
+                </Link>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  )
+}

--- a/app/(app)/home/[lang]/page.jsx
+++ b/app/(app)/home/[lang]/page.jsx
@@ -1,102 +1,21 @@
-'use client'
-
-import ErrorList from 'app/components/ErrorList'
 import { notFound } from 'next/navigation'
-import { useProfile } from 'app/data/hooks'
-import { useRecentReviews } from 'app/data/reviews'
-import Loading from 'app/loading'
 import languages from 'lib/languages'
-import Link from 'next/link'
-
-const RecentReviewsSummary = ({ lang }) => {
-  const { data, error, status } = useRecentReviews(lang)
-  if (status === 'loading') return <Loading />
-  if (error) return <ErrorList error={error} />
-
-  const countReviews = data?.length
-  const countPositive = data?.filter(r => r.score > 0).length
-
-  return (
-    <div className="text-base-content bg-base-200 card-body">
-      <div className="card-title">Review flash cards</div>
-      {countReviews > 5 &&
-        `You've been studying ${countReviews > 40 ? 'a lot!' : ' – '}`}{' '}
-      I see {countReviews} cards reviewed in the last week
-      {countPositive > 0 && ` and you remembered ${countPositive} of them`}.
-      Keep at it!
-    </div>
-  )
-}
-
-const CardsSummary = ({ deck }) => {
-  const { cards_active, cards_learned } = deck
-  const cardsInDeck = cards_active + cards_learned
-  const beHappy = cards_learned > 5
-  return (
-    <div className="text-base-content bg-base-200 card-body">
-      <div className="card-title">Manage your deck</div>
-      You have:
-      <ul className="ml-2 block">
-        <li>🎴 {cardsInDeck} cards in your deck</li>
-        <li>🤓 studying {cards_active} currently</li>
-        <li>
-          🎊 and you&apos;ve learned {cards_learned + ' '}
-          of them{beHappy ? '!' : '.'}
-        </li>
-      </ul>
-    </div>
-  )
-}
+import Client from './client'
 
 export default function Page({ params: { lang } }) {
-  const { data, error, status } = useProfile()
-  const deck = data?.deck_stubs?.find(d => d.lang === lang) || null
-  if (status === 'loading') return <Loading />
-  if (error) return <ErrorList error={error} />
-
-  // the long name
   const language = languages[lang]
   if (typeof language !== 'string') notFound()
 
   return (
     <>
       <h1 className="text-4xl mt-6 mb-4">Learn {language}</h1>
-      {data === null ? (
-        <p>
-          Are you sure you&apos;re learning this language? To create a deck and{' '}
-          <Link className="underline" href="/my-decks/new">
-            start learning {language}, click here
-          </Link>
-          .
-        </p>
-      ) : (
-        <div>
-          <div className="md:w-1/2 p-4 grid gap-4">
-            <div className="card w-96 glass">
-              <figure>
-                <RecentReviewsSummary lang={lang} />
-              </figure>
-              <div className="card-body">
-                <Link href={`/review/${lang}`} className="mx-auto btn">
-                  Start a review session
-                </Link>
-              </div>
-            </div>
-          </div>
-          <div className="w-100 md:w-1/2 p-4 grid gap-4">
-            <div className="card w-96 glass">
-              <figure>
-                <CardsSummary deck={deck} />
-              </figure>
-              <div className="card-body">
-                <Link href={`/my-decks/${lang}`} className="mx-auto btn">
-                  Browse/manage on your deck
-                </Link>
-              </div>
-            </div>
-          </div>
-        </div>
-      )}
+      <Client lang={lang} />
     </>
   )
+}
+
+export async function generateStaticParams() {
+  return Object.keys(languages).map(lang => ({
+    lang,
+  }))
 }

--- a/app/(app)/home/client.jsx
+++ b/app/(app)/home/client.jsx
@@ -10,8 +10,8 @@ export default function Client() {
   const { data: profile, isLoading } = useProfile()
   const { data: reviews } = useRecentReviewActivity()
   const activeDecks = reviews?.keysInOrder ?? []
+  // console.log(`This is the profile and reviews objects`, profile, reviews)
 
-  console.log(`This is the profile and reviews objects`, profile, reviews)
   const remainingDecks = useMemo(() => {
     if (!profile?.deck_stubs?.length) return null
     return profile.deck_stubs

--- a/app/(app)/home/client.jsx
+++ b/app/(app)/home/client.jsx
@@ -1,0 +1,43 @@
+'use client'
+
+import { useMemo } from 'react'
+import Link from 'next/link'
+import { useProfile, useRecentReviewActivity } from 'app/data/hooks'
+import languages from 'lib/languages'
+import Loading from 'app/loading'
+
+export default function Client() {
+  const { data: profile, isLoading } = useProfile()
+  const { data: reviews } = useRecentReviewActivity()
+  const activeDecks = reviews?.keysInOrder ?? []
+
+  console.log(`This is the profile and reviews objects`, profile, reviews)
+  const remainingDecks = useMemo(() => {
+    if (!profile?.deck_stubs?.length) return null
+    return profile.deck_stubs
+      .filter(d => !reviews?.keysInOrder?.includes(d.lang) ?? false)
+      .sort((left, right) => {
+        // the deck that was updated more recently sorts first
+        return left?.updated_at === right?.updated_at
+          ? 0
+          : left?.updated_at > right?.updated_at
+          ? -1
+          : 1
+      })
+      .map(d => d.lang)
+  }, [profile, reviews])
+
+  return isLoading ? (
+    <Loading />
+  ) : (
+    <ol>
+      {[...activeDecks, ...remainingDecks]?.map(lang => (
+        <li key={lang} className="glass p-2 rounded text-center my-2">
+          <Link href={`home/${lang}`}>
+            <p className="text-xl py-2">{languages[lang]}</p>
+          </Link>
+        </li>
+      ))}
+    </ol>
+  )
+}

--- a/app/(app)/home/page.jsx
+++ b/app/(app)/home/page.jsx
@@ -1,44 +1,11 @@
-'use client'
-
-import { useMemo } from 'react'
 import Link from 'next/link'
-import { useProfile, useRecentReviewActivity } from 'app/data/hooks'
-import languages from 'lib/languages'
-import Loading from 'app/loading'
+import Client from './client'
 
 export default function Page() {
-  const { data: profile, isLoading } = useProfile()
-  const { data: reviews, error } = useRecentReviewActivity()
-  const activeDecks = reviews?.keysInOrder ?? []
-
-  console.log(`This is the profile and reviews objects`, profile, reviews)
-  const remainingDecks = useMemo(() => {
-    if (!profile?.deck_stubs?.length) return null
-    return profile.deck_stubs
-      .filter(d => !reviews?.keysInOrder?.includes(d.lang) ?? false)
-      .sort((left, right) => {
-        // the deck that was updated more recently sorts first
-        return left?.updated_at === right?.updated_at
-          ? 0
-          : left?.updated_at > right?.updated_at
-          ? -1
-          : 1
-      })
-      .map(d => d.lang)
-  }, [profile, reviews])
-
-  return isLoading ? (
-    <Loading />
-  ) : (
+  return (
     <div className="form-control max-w-sm flex flex-col gap-4 p-2">
       <label className="label h2 text-center">Continue learning...</label>
-      {[...activeDecks, ...remainingDecks]?.map(lang => (
-        <div key={lang} className="glass p-2 rounded text-center">
-          <Link href={`home/${lang}`}>
-            <p className="text-xl py-2">{languages[lang]}</p>
-          </Link>
-        </div>
-      ))}
+      <Client />
       <div className="mx-auto">
         <Link href={`/my-decks/new`}>
           <span className="btn btn-ghost">+ Start a new language</span>

--- a/app/(app)/my-decks/[lang]/new-card/page.jsx
+++ b/app/(app)/my-decks/[lang]/new-card/page.jsx
@@ -15,3 +15,9 @@ export default function Page({ params: { lang } }) {
     </>
   )
 }
+
+export async function generateStaticParams() {
+  return Object.keys(languages).map(lang => ({
+    lang,
+  }))
+}

--- a/app/(app)/my-decks/[lang]/page.jsx
+++ b/app/(app)/my-decks/[lang]/page.jsx
@@ -19,3 +19,9 @@ export default function Page({ params: { lang } }) {
     </>
   )
 }
+
+export async function generateStaticParams() {
+  return Object.keys(languages).map(lang => ({
+    lang,
+  }))
+}

--- a/app/(app)/review/[lang]/page.jsx
+++ b/app/(app)/review/[lang]/page.jsx
@@ -1,5 +1,12 @@
+import languages from 'lib/languages'
 import ClientPage from './client'
 
 export default function Page({ params: { lang } }) {
   return <ClientPage lang={lang} />
+}
+
+export async function generateStaticParams() {
+  return Object.keys(languages).map(lang => ({
+    lang,
+  }))
 }

--- a/app/language/[lang]/page.jsx
+++ b/app/language/[lang]/page.jsx
@@ -47,9 +47,7 @@ export default async function Page({ params: { lang } }) {
 }
 
 export async function generateStaticParams() {
-  const data = languages
-
-  return Object.keys(data).map(lang => ({
+  return Object.keys(languages).map(lang => ({
     lang,
   }))
 }

--- a/app/phrase/[id]/page.jsx
+++ b/app/phrase/[id]/page.jsx
@@ -2,17 +2,23 @@ import Link from 'next/link'
 import { getAllPhraseDetails } from 'app/data/fetchers'
 import TinyPhrase from 'app/components/TinyPhrase'
 import languages from 'lib/languages'
+import { notFound } from 'next/navigation'
 
 export async function generateStaticParams() {
   let phrases = await getAllPhraseDetails()
-  return phrases.map(phrase => ({
-    id: phrase.id,
-  }))
+  return phrases.map(phrase => {
+    return phrase?.lang && phrase?.text && phrase?.id
+      ? {
+          id: phrase.id,
+        }
+      : null
+  })
 }
 
-export default async function Page({ params }) {
+export default async function Page({ params: { id } }) {
   const phrases = await getAllPhraseDetails()
-  const phrase = phrases.find(p => p.id === params.id)
+  const phrase = phrases.find(p => p.id === id)
+  if (!phrase) notFound()
 
   return (
     <div className="page-card gap-8 lg:w-[50vw] w-96">

--- a/next.config.js
+++ b/next.config.js
@@ -1,15 +1,5 @@
 module.exports = {
+  output: 'export',
+  images: { unoptimized: true },
   reactStrictMode: true,
-  images: {
-    remotePatterns: [
-      {
-        protocol: 'https',
-        hostname: 'hepudeougzlgnuqvybrj.supabase.co',
-      },
-      {
-        protocol: 'https',
-        hostname: 'next.sunlo.co',
-      },
-    ],
-  },
 }

--- a/sunlo.code-workspace
+++ b/sunlo.code-workspace
@@ -11,7 +11,8 @@
   ],
   "settings": {
     "files.exclude": {
-      "supabase/functions/": true
+      "supabase/functions/": true,
+      "out/": true
     }
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -34,6 +34,7 @@
     "**/*.jsx",
   ],
   "exclude": [
-    "node_modules"
+    "node_modules",
+    "out",
   ]
 }


### PR DESCRIPTION
In order to try out a technology called Tauri we'll need the site to be exportable to static assets. This is a good set of more strict standards to follow that will help the app perform better regardless, so it gets its own PR.

Mostly what this PR does is add `generateStaticParams` to all the `page.jsx`s, which means it can't use `'use client'` so if the pages use any hooks we need to split them into a Client component. It also disables image optimisation, because that doesn't work for static outputs, but this should be negligible, or fixable with a one-time action of converting profile pics to 144x144 upon save, or fetching the correct sizing directly from supabase (if that's possible).