### PR TITLE
Add a mobile-worthy Navbar

### DIFF
--- a/app/(app)/Navbar.jsx
+++ b/app/(app)/Navbar.jsx
@@ -1,0 +1,77 @@
+'use client'
+
+import { useRouter, useSelectedLayoutSegments } from 'next/navigation'
+import { useState } from 'react'
+
+export default function Navbar() {
+  const segments = useSelectedLayoutSegments()
+  const router = useRouter()
+  const [isContextMenuOpen, setIsContextMenuOpen] = useState()
+  const openContextMenu = () => setIsContextMenuOpen(true)
+  return (
+    <div
+      className="
+      w-full
+      fixed left-0 right-0 top-0
+    "
+    >
+      <nav
+        className="max-w-prose mx-auto p-2
+      text-xl flex flex-row justify-between items-center
+      shadow shadow-white/20
+      "
+      >
+        <a
+          href="#"
+          className="btn btn-ghost rounded-full gap-2"
+          onClick={() => router.back()}
+        >
+          <LeftArrow /> <span className="max-sm:hidden">Go back</span>
+        </a>
+        <p className="grow px-4">Learn Arabic</p>
+        <a
+          href="#"
+          className="btn btn-ghost rounded-full gap-2"
+          onClick={openContextMenu}
+        >
+          <span className="max-sm:hidden">More </span>
+          <ContextMenuIcon />
+        </a>
+      </nav>
+    </div>
+  )
+}
+
+const ContextMenuIcon = () => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 24 24"
+    strokeWidth={1.5}
+    stroke="currentColor"
+    className="size-6"
+  >
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      d="M12 6.75a.75.75 0 1 1 0-1.5.75.75 0 0 1 0 1.5ZM12 12.75a.75.75 0 1 1 0-1.5.75.75 0 0 1 0 1.5ZM12 18.75a.75.75 0 1 1 0-1.5.75.75 0 0 1 0 1.5Z"
+    />
+  </svg>
+)
+
+const LeftArrow = () => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 24 24"
+    strokeWidth={1.5}
+    stroke="currentColor"
+    className="size-6"
+  >
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      d="M10.5 19.5 3 12m0 0 7.5-7.5M3 12h18"
+    />
+  </svg>
+)

--- a/app/(app)/Navbar.jsx
+++ b/app/(app)/Navbar.jsx
@@ -21,21 +21,21 @@ export default function Navbar({ title, children }) {
           <LeftArrow /> <span className="sr-only">Go back</span>
         </a>
         <h1 className="grow px-4 text-2xl my-0 text-center">{title}</h1>
-        <a
-          className="btn btn-ghost rounded-full gap-2"
-          onClick={openContextMenu}
-        >
-          {children ?? (
-            <>
-              <span className="sr-only">More options</span>
-              <ContextMenuIcon />
-            </>
-          )}
-        </a>
+        {children}
       </nav>
     </div>
   )
 }
+
+/*
+  <span
+    className="btn btn-ghost rounded-full gap-2"
+    onClick={openContextMenu}
+  >
+    <span className="sr-only">More options</span>
+    <ContextMenuIcon />
+  </span>
+*/
 
 const ContextMenuIcon = () => (
   <svg

--- a/app/(app)/Navbar.jsx
+++ b/app/(app)/Navbar.jsx
@@ -22,7 +22,6 @@ export default function Navbar({ title, children }) {
         </a>
         <h1 className="grow px-4 text-2xl my-0 text-center">{title}</h1>
         <a
-          href="#"
           className="btn btn-ghost rounded-full gap-2"
           onClick={openContextMenu}
         >

--- a/app/(app)/Navbar.jsx
+++ b/app/(app)/Navbar.jsx
@@ -26,7 +26,7 @@ export default function Navbar({ title }) {
           className="btn btn-ghost rounded-full gap-2"
           onClick={openContextMenu}
         >
-          <span className="max-sm:hidden sr-only">More options</span>
+          <span className="sr-only">More options</span>
           <ContextMenuIcon />
         </a>
       </nav>

--- a/app/(app)/Navbar.jsx
+++ b/app/(app)/Navbar.jsx
@@ -6,7 +6,7 @@ import {
 } from 'next/navigation'
 import { useState } from 'react'
 
-export default function Navbar({ title }) {
+export default function Navbar({ title, children }) {
   // const segments = useSelectedLayoutSegments()
   const router = useRouter()
   const [isContextMenuOpen, setIsContextMenuOpen] = useState()
@@ -20,14 +20,18 @@ export default function Navbar({ title }) {
         >
           <LeftArrow /> <span className="sr-only">Go back</span>
         </a>
-        <h1 className="grow px-4 text-2xl my-0">{title}</h1>
+        <h1 className="grow px-4 text-2xl my-0 text-center">{title}</h1>
         <a
           href="#"
           className="btn btn-ghost rounded-full gap-2"
           onClick={openContextMenu}
         >
-          <span className="sr-only">More options</span>
-          <ContextMenuIcon />
+          {children ?? (
+            <>
+              <span className="sr-only">More options</span>
+              <ContextMenuIcon />
+            </>
+          )}
         </a>
       </nav>
     </div>

--- a/app/(app)/Navbar.jsx
+++ b/app/(app)/Navbar.jsx
@@ -1,10 +1,13 @@
 'use client'
 
-import { useRouter, useSelectedLayoutSegments } from 'next/navigation'
+import {
+  useRouter,
+  //  useSelectedLayoutSegments
+} from 'next/navigation'
 import { useState } from 'react'
 
-export default function Navbar() {
-  const segments = useSelectedLayoutSegments()
+export default function Navbar({ title }) {
+  // const segments = useSelectedLayoutSegments()
   const router = useRouter()
   const [isContextMenuOpen, setIsContextMenuOpen] = useState()
   const openContextMenu = () => setIsContextMenuOpen(true)
@@ -17,7 +20,7 @@ export default function Navbar() {
         >
           <LeftArrow /> <span className="max-sm:hidden">Go back</span>
         </a>
-        <p className="grow px-4">Learn Arabic</p>
+        <p className="grow px-4">{title}</p>
         <a
           href="#"
           className="btn btn-ghost rounded-full gap-2"

--- a/app/(app)/Navbar.jsx
+++ b/app/(app)/Navbar.jsx
@@ -12,21 +12,21 @@ export default function Navbar({ title }) {
   const [isContextMenuOpen, setIsContextMenuOpen] = useState()
   const openContextMenu = () => setIsContextMenuOpen(true)
   return (
-    <div className="w-full fixed left-0 right-0 top-0">
+    <div className="w-full fixed left-0 right-0 top-0 border-b border-base-100/30">
       <nav className="w-app p-2 border-bottom text-xl flex flex-row justify-between items-center">
         <a
           onClick={() => router.back()}
           className="btn btn-ghost rounded-full gap-2"
         >
-          <LeftArrow /> <span className="max-sm:hidden">Go back</span>
+          <LeftArrow /> <span className="sr-only">Go back</span>
         </a>
-        <p className="grow px-4">{title}</p>
+        <h1 className="grow px-4 text-2xl my-0">{title}</h1>
         <a
           href="#"
           className="btn btn-ghost rounded-full gap-2"
           onClick={openContextMenu}
         >
-          <span className="max-sm:hidden">More </span>
+          <span className="max-sm:hidden sr-only">More options</span>
           <ContextMenuIcon />
         </a>
       </nav>

--- a/app/(app)/Navbar.jsx
+++ b/app/(app)/Navbar.jsx
@@ -9,22 +9,11 @@ export default function Navbar() {
   const [isContextMenuOpen, setIsContextMenuOpen] = useState()
   const openContextMenu = () => setIsContextMenuOpen(true)
   return (
-    <div
-      className="
-      w-full
-      fixed left-0 right-0 top-0
-    "
-    >
-      <nav
-        className="max-w-prose mx-auto p-2
-      text-xl flex flex-row justify-between items-center
-      shadow shadow-white/20
-      "
-      >
+    <div className="w-full fixed left-0 right-0 top-0">
+      <nav className="w-app p-2 border-bottom text-xl flex flex-row justify-between items-center">
         <a
-          href="#"
-          className="btn btn-ghost rounded-full gap-2"
           onClick={() => router.back()}
+          className="btn btn-ghost rounded-full gap-2"
         >
           <LeftArrow /> <span className="max-sm:hidden">Go back</span>
         </a>

--- a/app/(app)/home/[lang]/client.jsx
+++ b/app/(app)/home/[lang]/client.jsx
@@ -74,9 +74,12 @@ export default function Client({ lang }) {
             <figure>
               <RecentReviewsSummary lang={lang} />
             </figure>
-            <div className="card-body">
-              <Link href={`/review/${lang}`} className="mx-auto btn">
+            <div className="card-body flex-row justify-between">
+              <Link href={`/review/${lang}`} className="btn">
                 Start a review session
+              </Link>
+              <Link href={`/review/${lang}`} className="btn">
+                See your review stats
               </Link>
             </div>
           </div>
@@ -86,8 +89,8 @@ export default function Client({ lang }) {
               <CardsSummary deck={deck} />
             </figure>
             <div className="card-body">
-              <Link href={`/my-decks/${lang}`} className="mx-auto btn">
-                Browse/manage on your deck
+              <Link href={`/my-decks/${lang}`} className="btn">
+                Browse/manage your deck
               </Link>
             </div>
           </div>

--- a/app/(app)/home/[lang]/client.jsx
+++ b/app/(app)/home/[lang]/client.jsx
@@ -69,7 +69,7 @@ export default function Client({ lang }) {
           .
         </p>
       ) : (
-        <div className="grid gap-4 min-w-44 w-[90vw] max-w-[22rem]">
+        <div className="grid gap-4 max-w-[44rem]">
           <div className="card glass">
             <figure>
               <RecentReviewsSummary lang={lang} />

--- a/app/(app)/home/[lang]/client.jsx
+++ b/app/(app)/home/[lang]/client.jsx
@@ -69,17 +69,14 @@ export default function Client({ lang }) {
           .
         </p>
       ) : (
-        <div className="grid gap-4 max-w-[44rem]">
+        <div className="grid gap-6 max-w-[44rem]">
           <div className="card glass">
             <figure>
               <RecentReviewsSummary lang={lang} />
             </figure>
-            <div className="card-body flex-row justify-between">
-              <Link href={`/review/${lang}`} className="btn">
+            <div className="card-body">
+              <Link href={`/review/${lang}`} className="btn btn-lg">
                 Start a review session
-              </Link>
-              <Link href={`/review/${lang}`} className="btn">
-                See your review stats
               </Link>
             </div>
           </div>
@@ -89,7 +86,7 @@ export default function Client({ lang }) {
               <CardsSummary deck={deck} />
             </figure>
             <div className="card-body">
-              <Link href={`/my-decks/${lang}`} className="btn">
+              <Link href={`/my-decks/${lang}`} className="btn btn-lg">
                 Browse/manage your deck
               </Link>
             </div>

--- a/app/(app)/home/[lang]/page.jsx
+++ b/app/(app)/home/[lang]/page.jsx
@@ -1,4 +1,5 @@
 import { notFound } from 'next/navigation'
+import Navbar from 'app/(app)/Navbar'
 import languages from 'lib/languages'
 import Client from './client'
 
@@ -7,10 +8,12 @@ export default function Page({ params: { lang } }) {
   if (typeof language !== 'string') notFound()
 
   return (
-    <main>
-      <h1 className="text-4xl mt-6 mb-4">Learn {language}</h1>
+    <>
+      <Navbar title={`Learning ${language}`} />
+      <main className="mx-auto">
       <Client lang={lang} />
     </main>
+    </>
   )
 }
 

--- a/app/(app)/home/[lang]/page.jsx
+++ b/app/(app)/home/[lang]/page.jsx
@@ -11,8 +11,8 @@ export default function Page({ params: { lang } }) {
     <>
       <Navbar title={`Learning ${language}`} />
       <main className="mx-auto">
-      <Client lang={lang} />
-    </main>
+        <Client lang={lang} />
+      </main>
     </>
   )
 }

--- a/app/(app)/home/page.jsx
+++ b/app/(app)/home/page.jsx
@@ -3,7 +3,7 @@ import Client from './client'
 
 export default function Page() {
   return (
-    <main className="max-w-sm flex flex-col gap-4 p-2">
+    <main className="flex flex-col gap-4 p-2">
       <label className="label h2 text-center">Continue learning...</label>
       <Client />
       <div className="mx-auto">

--- a/app/(app)/home/page.jsx
+++ b/app/(app)/home/page.jsx
@@ -5,14 +5,11 @@ import Client from './client'
 export default function Page() {
   return (
     <>
-      <Navbar title={`Continue learning...`} />
+      <Navbar title={`Continue learning...`}>
+        <Link href={`/my-decks/new`}>+ new neck</Link>
+      </Navbar>
       <main className="flex flex-col gap-4 p-2">
         <Client />
-        <div className="mx-auto">
-          <Link href={`/my-decks/new`}>
-            <span className="btn btn-ghost">+ Start a new language</span>
-          </Link>
-        </div>
       </main>
     </>
   )

--- a/app/(app)/home/page.jsx
+++ b/app/(app)/home/page.jsx
@@ -6,7 +6,7 @@ export default function Page() {
   return (
     <>
       <Navbar title={`Continue learning...`}>
-        <Link href={`/my-decks/new`}>+ new neck</Link>
+        <Link href={`/my-decks/new`}>+ deck</Link>
       </Navbar>
       <main className="flex flex-col gap-4 p-2">
         <Client />

--- a/app/(app)/home/page.jsx
+++ b/app/(app)/home/page.jsx
@@ -1,16 +1,19 @@
 import Link from 'next/link'
+import Navbar from '../Navbar'
 import Client from './client'
 
 export default function Page() {
   return (
-    <main className="flex flex-col gap-4 p-2">
-      <label className="label h2 text-center">Continue learning...</label>
-      <Client />
-      <div className="mx-auto">
-        <Link href={`/my-decks/new`}>
-          <span className="btn btn-ghost">+ Start a new language</span>
-        </Link>
-      </div>
-    </main>
+    <>
+      <Navbar title={`Continue learning...`} />
+      <main className="flex flex-col gap-4 p-2">
+        <Client />
+        <div className="mx-auto">
+          <Link href={`/my-decks/new`}>
+            <span className="btn btn-ghost">+ Start a new language</span>
+          </Link>
+        </div>
+      </main>
+    </>
   )
 }

--- a/app/(app)/layout.jsx
+++ b/app/(app)/layout.jsx
@@ -1,10 +1,8 @@
 import LoginChallenge from './login-challenge'
-import Navbar from 'app/(app)/Navbar'
 
 export default function Layout({ children }) {
   return (
-    <div className="w-full max-w-prose mx-auto pt-12">
-      <Navbar />
+    <div className="w-app">
       <LoginChallenge />
       {children}
     </div>

--- a/app/(app)/layout.jsx
+++ b/app/(app)/layout.jsx
@@ -2,7 +2,7 @@ import LoginChallenge from './login-challenge'
 
 export default function Layout({ children }) {
   return (
-    <div className="w-app">
+    <div className="w-app my-4">
       <LoginChallenge />
       {children}
     </div>

--- a/app/(app)/layout.jsx
+++ b/app/(app)/layout.jsx
@@ -1,8 +1,10 @@
 import LoginChallenge from './login-challenge'
+import Navbar from 'app/(app)/Navbar'
 
 export default function Layout({ children }) {
   return (
-    <div className="w-full max-w-prose mx-auto">
+    <div className="w-full max-w-prose mx-auto pt-12">
+      <Navbar />
       <LoginChallenge />
       {children}
     </div>

--- a/app/(app)/login-challenge.jsx
+++ b/app/(app)/login-challenge.jsx
@@ -14,7 +14,7 @@ export default function LoginChallenge() {
   return (
     <Modal
       isOpen={!isDismissed && !isAuth}
-      className="big-card my-6 mx-auto w-11/12 place-self-center outline-none"
+      className="card-white w-app my-6 place-self-center outline-none max-sm:mx-1"
       overlayClassName="bg-black/60 fixed backdrop-blur-sm fixed inset-0 flex"
       noScroll={true}
       handleCloseModal={() => setIsDismissed(true)}

--- a/app/(app)/login-challenge.jsx
+++ b/app/(app)/login-challenge.jsx
@@ -14,7 +14,7 @@ export default function LoginChallenge() {
   return (
     <Modal
       isOpen={!isDismissed && !isAuth}
-      className="card-white w-app my-6 place-self-center outline-none max-sm:mx-1"
+      className="@container card-white w-app my-6 place-self-center outline-none max-sm:mx-1"
       overlayClassName="bg-black/60 fixed backdrop-blur-sm fixed inset-0 flex"
       noScroll={true}
       handleCloseModal={() => setIsDismissed(true)}

--- a/app/(app)/my-decks/[lang]/ClientPage.jsx
+++ b/app/(app)/my-decks/[lang]/ClientPage.jsx
@@ -86,8 +86,7 @@ export default function ClientPage({ lang }) {
           className={`tab tab-bordered ${tab === 'browse' ? 'tab-active' : ''}`}
           onClick={() => setTab('browse')}
         >
-          <>Browse&nbsp;</>
-          <span className="hidden md:block">for new&nbsp;</span>phrases...
+          Browse phrases...
         </a>
       </div>
       <div>

--- a/app/(app)/my-decks/[lang]/NewCardLinkAndModal.jsx
+++ b/app/(app)/my-decks/[lang]/NewCardLinkAndModal.jsx
@@ -10,7 +10,7 @@ export default function NewCardLinkAndModal({ lang }) {
     <>
       <a
         onClick={() => setShowModal(true)}
-        className="flex-none link place-self-center"
+        className="flex-none place-self-center"
       >
         + new card
       </a>

--- a/app/(app)/my-decks/[lang]/new-card/form.jsx
+++ b/app/(app)/my-decks/[lang]/new-card/form.jsx
@@ -99,6 +99,10 @@ export default function AddCardPhraseForm({ lang, cancel }) {
   }
   return (
     <form className="flex flex-col gap-4" onSubmit={handleSubmit}>
+      <h2 className="h3">
+        Enter the {languages[lang]} phrase and a translation
+      </h2>
+
       <div className="">
         <div className="form-control">
           <label>{languages[lang]} phrase to learn</label>

--- a/app/(app)/my-decks/[lang]/new-card/page.jsx
+++ b/app/(app)/my-decks/[lang]/new-card/page.jsx
@@ -1,18 +1,15 @@
-import Link from 'next/link'
 import languages from 'lib/languages'
 import AddCardPhraseForm from './form'
+import Navbar from 'app/(app)/Navbar'
 
 export default function Page({ params: { lang } }) {
   return (
-    <main>
-      <Link href={`/my-decks/${lang}`} className="link">
-        &larr; Back to {languages[lang]} deck
-      </Link>
-      <h1 className="h1">Add a new card</h1>
-      <div className="card bg-base-100 text-base-content card-body">
+    <>
+      <Navbar title={`Add a new ${languages[lang]} phrase`}></Navbar>
+      <main className="card-white">
         <AddCardPhraseForm lang={lang} />
-      </div>
-    </main>
+      </main>
+    </>
   )
 }
 

--- a/app/(app)/my-decks/[lang]/new-card/page.jsx
+++ b/app/(app)/my-decks/[lang]/new-card/page.jsx
@@ -9,7 +9,7 @@ export default function Page({ params: { lang } }) {
         &larr; Back to {languages[lang]} deck
       </Link>
       <h1 className="h1">Add a new card</h1>
-      <div className="section-card">
+      <div className="card bg-base-100 text-base-content card-body">
         <AddCardPhraseForm lang={lang} />
       </div>
     </main>

--- a/app/(app)/my-decks/[lang]/page.jsx
+++ b/app/(app)/my-decks/[lang]/page.jsx
@@ -10,7 +10,7 @@ export default function Page({ params: { lang } }) {
         <NewCardLinkAndModal lang={lang} />
       </Navbar>
       <main>
-        <div className="card card-body bg-base-100 text-base-content">
+        <div className="card-white">
           <ClientPage lang={lang} />
         </div>
       </main>

--- a/app/(app)/my-decks/[lang]/page.jsx
+++ b/app/(app)/my-decks/[lang]/page.jsx
@@ -13,7 +13,7 @@ export default function Page({ params: { lang } }) {
         <h1 className="h1">Learn {languages[lang]}</h1>
         <NewCardLinkAndModal lang={lang} />
       </div>
-      <div className="page-card">
+      <div className="card card-body bg-base-100 text-base-content">
         <ClientPage lang={lang} />
       </div>
     </main>

--- a/app/(app)/my-decks/[lang]/page.jsx
+++ b/app/(app)/my-decks/[lang]/page.jsx
@@ -1,22 +1,20 @@
-import Link from 'next/link'
 import languages from 'lib/languages'
-import NewCardLinkAndModal from 'app/components/NewCardLinkAndModal'
+import NewCardLinkAndModal from './NewCardLinkAndModal'
 import ClientPage from './ClientPage'
+import Navbar from 'app/(app)/Navbar'
 
 export default function Page({ params: { lang } }) {
   return (
-    <main>
-      <Link className="link" href="/my-decks">
-        &larr; Back to decks
-      </Link>
-      <div className="flex flex-row justify-between">
-        <h1 className="h1">Learn {languages[lang]}</h1>
+    <>
+      <Navbar title={`Manage your ${languages[lang]} flashcards`}>
         <NewCardLinkAndModal lang={lang} />
-      </div>
-      <div className="card card-body bg-base-100 text-base-content">
-        <ClientPage lang={lang} />
-      </div>
-    </main>
+      </Navbar>
+      <main>
+        <div className="card card-body bg-base-100 text-base-content">
+          <ClientPage lang={lang} />
+        </div>
+      </main>
+    </>
   )
 }
 

--- a/app/(app)/my-decks/new/form.jsx
+++ b/app/(app)/my-decks/new/form.jsx
@@ -45,6 +45,7 @@ export default function Form() {
         status === 'error' && <ErrorList summary={`${error.message}`} />
       )}
       <form name="new-deck" onSubmit={createNewDeck.mutate}>
+        <h2 className="h3">What language would you like to learn?</h2>
         <Select
           options={allLanguageOptions}
           isOptionDisabled={option =>

--- a/app/(app)/my-decks/new/page.jsx
+++ b/app/(app)/my-decks/new/page.jsx
@@ -1,16 +1,15 @@
-import Link from 'next/link'
 import Form from './form'
+import Navbar from 'app/(app)/Navbar'
 
 export default function Page() {
   return (
-    <main>
-      <Link href="/my-decks" className="hover:underline">
-        &larr; Back to decks
-      </Link>
-      <h1 className="h1">Start a new deck</h1>
-      <div className="card card-body bg-base-100 text-base-content">
-        <Form />
-      </div>
-    </main>
+    <>
+      <Navbar title="Start Learning" />
+      <main>
+        <div className="card card-body bg-base-100 text-base-content">
+          <Form />
+        </div>
+      </main>
+    </>
   )
 }

--- a/app/(app)/my-decks/new/page.jsx
+++ b/app/(app)/my-decks/new/page.jsx
@@ -5,10 +5,8 @@ export default function Page() {
   return (
     <>
       <Navbar title="Start Learning" />
-      <main>
-        <div className="card card-body bg-base-100 text-base-content">
-          <Form />
-        </div>
+      <main className="card-white">
+        <Form />
       </main>
     </>
   )

--- a/app/(app)/my-decks/new/page.jsx
+++ b/app/(app)/my-decks/new/page.jsx
@@ -8,7 +8,7 @@ export default function Page() {
         &larr; Back to decks
       </Link>
       <h1 className="h1">Start a new deck</h1>
-      <div className="page-card">
+      <div className="card card-body bg-base-100 text-base-content">
         <Form />
       </div>
     </main>

--- a/app/(app)/my-decks/page.jsx
+++ b/app/(app)/my-decks/page.jsx
@@ -8,11 +8,8 @@ export default function Page() {
       <Navbar title="My languages">
         <Link href="/my-decks/new">+ new deck</Link>
       </Navbar>
-      <main>
-        <div className="flex justify-between"></div>
-        <div className="page-card">
-          <ClientPage />
-        </div>
+      <main className="page-card">
+        <ClientPage />
       </main>
     </>
   )

--- a/app/(app)/my-decks/page.jsx
+++ b/app/(app)/my-decks/page.jsx
@@ -1,23 +1,19 @@
 import Link from 'next/link'
 import ClientPage from './ClientPage'
+import Navbar from '../Navbar'
 
 export default function Page() {
   return (
-    <main>
-      <div className="flex justify-between">
-        <div className="grow">
-          <h1 className="h1">My decks</h1>
+    <>
+      <Navbar title="My languages">
+        <Link href="/my-decks/new">+ new deck</Link>
+      </Navbar>
+      <main>
+        <div className="flex justify-between"></div>
+        <div className="page-card">
+          <ClientPage />
         </div>
-        <Link
-          className="flex-none link place-self-center text-white my-4"
-          href="/my-decks/new"
-        >
-          + new deck
-        </Link>
-      </div>
-      <div className="page-card">
-        <ClientPage />
-      </div>
-    </main>
+      </main>
+    </>
   )
 }

--- a/app/(app)/review/[lang]/card.jsx
+++ b/app/(app)/review/[lang]/card.jsx
@@ -52,7 +52,7 @@ export default function CardInner({ card, nextCard, addReview, hidden }) {
     },
   })
 
-  const btnClasses = `max-md:grow w-44 md:shrink`
+  const btnClasses = `grow basis-44`
 
   return hidden ? null : (
     <div className="card-white">

--- a/app/(app)/review/[lang]/card.jsx
+++ b/app/(app)/review/[lang]/card.jsx
@@ -59,7 +59,7 @@ export default function CardInner({ card, nextCard, addReview, hidden }) {
       <div className="flex flex-col justify-center text-center gap-8">
         <h2 className="h2 text-center">{card?.phrase?.text}</h2>
         {status === 'loading' ? (
-          <div className="absolute bg-white/70 top-0 left-0 right-0 bottom-0 content-center">
+          <div className="absolute bg-base-100/70 top-0 left-0 right-0 bottom-0 content-center">
             <Loading />
           </div>
         ) : null}

--- a/app/(app)/review/[lang]/card.jsx
+++ b/app/(app)/review/[lang]/card.jsx
@@ -55,7 +55,7 @@ export default function CardInner({ card, nextCard, addReview, hidden }) {
   const btnClasses = `max-md:grow w-44 md:shrink`
 
   return hidden ? null : (
-    <div className="big-card">
+    <div className="card-white">
       <div className="flex flex-col justify-center text-center gap-8">
         <h2 className="h2 text-center">{card?.phrase?.text}</h2>
         {status === 'loading' ? (
@@ -64,7 +64,7 @@ export default function CardInner({ card, nextCard, addReview, hidden }) {
           </div>
         ) : null}
         {status === 'error' ? (
-          <div className="absolute bg-white/50 top-0 left-0 right-0 bottom-0">
+          <div className="absolute bg-base-100/50 top-0 left-0 right-0 bottom-0">
             <ErrorList error={error} />
           </div>
         ) : null}

--- a/app/(app)/review/[lang]/client.jsx
+++ b/app/(app)/review/[lang]/client.jsx
@@ -2,6 +2,7 @@
 
 import { useMemo, useState } from 'react'
 import languages from 'lib/languages'
+import Navbar from 'app/(app)/Navbar'
 import { useDeck } from 'app/data/hooks'
 import Loading from 'app/loading'
 import SuccessCheckmark from 'app/components/SvgComponents'
@@ -51,19 +52,13 @@ export default function ClientPage({ lang }) {
   }
 
   return (
-    <div className="h-full grid gap-8 max-w-xl mx-auto">
-      <p className="inline-block">
-        <span className="alert alert-info inline-block text-info-content text-center">
-          Reviewing {languages[lang]} flash cards.{' '}
-          {reviewCards.length - cardIndex} cards left today{' '}
-          {cardIndex < reviewCards.length ? (
-            <>
-              ({cardIndex + 1} out of {reviewCards.length})
-            </>
-          ) : null}
-        </span>
-      </p>
-      <div className="flex justify-center gap-4">
+    <div className="h-full grid gap-8 pt-10 @lg:pt-0">
+      <Navbar
+        title={`Reviewing ${languages[lang]} (${cardIndex + 1} out of ${
+          reviewCards.length
+        })`}
+      />
+      <div className="flex justify-center gap-4 absolute @lg:static bottom-10 left-0 right-0">
         <button
           className="btn btn-primary"
           onClick={gobackaCard}

--- a/app/(app)/review/[lang]/client.jsx
+++ b/app/(app)/review/[lang]/client.jsx
@@ -53,7 +53,7 @@ export default function ClientPage({ lang }) {
   return (
     <div className="h-full grid gap-8 max-w-xl mx-auto">
       <p className="inline-block">
-        <span className="alert alert-info inline-block text-white text-center">
+        <span className="alert alert-info inline-block text-info-content text-center">
           Reviewing {languages[lang]} flash cards.{' '}
           {reviewCards.length - cardIndex} cards left today{' '}
           {cardIndex < reviewCards.length ? (
@@ -65,14 +65,14 @@ export default function ClientPage({ lang }) {
       </p>
       <div className="flex justify-center gap-4">
         <button
-          className="btn btn-outline btn-primary bg-white"
+          className="btn btn-primary"
           onClick={gobackaCard}
           disabled={!canBackup}
         >
           Prev card
         </button>
         <button
-          className="btn btn-outline btn-primary bg-white"
+          className="btn btn-primary"
           onClick={advanceCard}
           disabled={!canAdvance}
         >

--- a/app/(auth)/forgot-password/page.jsx
+++ b/app/(auth)/forgot-password/page.jsx
@@ -2,7 +2,7 @@ import ForgotPasswordForm from './form'
 
 export default function Page() {
   return (
-    <main className="card-white card-body">
+    <main className="card-body">
       <ForgotPasswordForm />
     </main>
   )

--- a/app/(auth)/forgot-password/page.jsx
+++ b/app/(auth)/forgot-password/page.jsx
@@ -2,7 +2,7 @@ import ForgotPasswordForm from './form'
 
 export default function Page() {
   return (
-    <main className="card-body">
+    <main className="card-white">
       <ForgotPasswordForm />
     </main>
   )

--- a/app/(auth)/forgot-password/page.jsx
+++ b/app/(auth)/forgot-password/page.jsx
@@ -2,10 +2,8 @@ import ForgotPasswordForm from './form'
 
 export default function Page() {
   return (
-    <main className="card bg-base-100 text-base-content">
-      <div className="card-body">
-        <ForgotPasswordForm />
-      </div>
+    <main className="card-white card-body">
+      <ForgotPasswordForm />
     </main>
   )
 }

--- a/app/(auth)/layout.jsx
+++ b/app/(auth)/layout.jsx
@@ -1,3 +1,3 @@
 export default function Layout({ children }) {
-  return <div className="w-full max-w-md mx-auto">{children}</div>
+  return <div className="w-full max-w-md mx-auto mt-[10cqh]">{children}</div>
 }

--- a/app/(auth)/login/page.jsx
+++ b/app/(auth)/login/page.jsx
@@ -3,7 +3,7 @@ import ClientPage from './client'
 
 export default function Page() {
   return (
-    <main className="card-white card-body">
+    <main className="card-white">
       <ClientPage>
         <LoginForm />
       </ClientPage>

--- a/app/(auth)/login/page.jsx
+++ b/app/(auth)/login/page.jsx
@@ -3,12 +3,10 @@ import ClientPage from './client'
 
 export default function Page() {
   return (
-    <main className="card bg-base-100 text-base-content">
-      <div className="card-body">
-        <ClientPage>
-          <LoginForm />
-        </ClientPage>
-      </div>
+    <main className="card-white card-body">
+      <ClientPage>
+        <LoginForm />
+      </ClientPage>
     </main>
   )
 }

--- a/app/(auth)/set-new-password/form.jsx
+++ b/app/(auth)/set-new-password/form.jsx
@@ -25,65 +25,57 @@ export default function SetNewPasswordForm() {
     },
   })
 
-  return (
-    <div className="section-card-inner">
-      {submitNewPassword.isSuccess ? (
-        <SuccessfulSubmit />
-      ) : !isAuth ? (
-        <InvalidLink />
-      ) : (
-        <>
-          <h1 className="h3 text-base-content/90">Choose a new password</h1>
-          <form
-            role="form"
-            onSubmit={submitNewPassword.mutate}
-            className="form"
-          >
-            <fieldset
-              className="flex flex-col gap-y-4"
+  return submitNewPassword.isSuccess ? (
+    <SuccessfulSubmit />
+  ) : !isAuth ? (
+    <InvalidLink />
+  ) : (
+    <>
+      <h1 className="h3 text-base-content/90">Choose a new password</h1>
+      <form role="form" onSubmit={submitNewPassword.mutate} className="form">
+        <fieldset
+          className="flex flex-col gap-y-4"
+          disabled={submitNewPassword.isSubmitting}
+        >
+          <div>
+            <p>
+              <label htmlFor="password">New password</label>
+            </p>
+            <input
+              id="password"
+              name="password"
+              required="required"
+              aria-invalid={
+                submitNewPassword.error?.errors?.password ? 'true' : 'false'
+              }
+              className={`${
+                submitNewPassword.error?.errors?.password
+                  ? 'border-error/60'
+                  : ''
+              } rounded-md w-full`}
+              tabIndex="1"
+              type="password"
+              placeholder="new password"
+            />
+          </div>
+          <div className="flex flex-row justify-between">
+            <button
+              tabIndex="3"
+              className="btn btn-primary"
+              type="submit"
               disabled={submitNewPassword.isSubmitting}
+              aria-disabled={submitNewPassword.isSubmitting}
             >
-              <div>
-                <p>
-                  <label htmlFor="password">New password</label>
-                </p>
-                <input
-                  id="password"
-                  name="password"
-                  required="required"
-                  aria-invalid={
-                    submitNewPassword.error?.errors?.password ? 'true' : 'false'
-                  }
-                  className={`${
-                    submitNewPassword.error?.errors?.password
-                      ? 'border-error/60'
-                      : ''
-                  } rounded-md w-full`}
-                  tabIndex="1"
-                  type="password"
-                  placeholder="new password"
-                />
-              </div>
-              <div className="flex flex-row justify-between">
-                <button
-                  tabIndex="3"
-                  className="btn btn-primary"
-                  type="submit"
-                  disabled={submitNewPassword.isSubmitting}
-                  aria-disabled={submitNewPassword.isSubmitting}
-                >
-                  Set new password
-                </button>
-              </div>
-            </fieldset>
-          </form>
-          <ErrorList
-            summary="Error setting new password"
-            error={submitNewPassword.error?.message}
-          />
-        </>
-      )}
-    </div>
+              Set new password
+            </button>
+          </div>
+        </fieldset>
+      </form>
+      <ErrorList
+        summary="Error setting new password"
+        error={submitNewPassword.error?.message}
+      />
+    </>
   )
 }
 

--- a/app/(auth)/set-new-password/page.jsx
+++ b/app/(auth)/set-new-password/page.jsx
@@ -2,10 +2,8 @@ import SetNewPasswordForm from './form'
 
 export default function SetNewPassword() {
   return (
-    <main className="card bg-base-100 text-base-content">
-      <div className="card-body">
-        <SetNewPasswordForm />
-      </div>
+    <main className="card card-body bg-base-100 text-base-content">
+      <SetNewPasswordForm />
     </main>
   )
 }

--- a/app/(auth)/signup/form.jsx
+++ b/app/(auth)/signup/form.jsx
@@ -113,7 +113,7 @@ export default function SignupForm() {
 }
 
 const SuccessfulSubmit = () => (
-  <div className="flex flex-col space-y-4 p-4 sm:p-6 md:p-10">
+  <div className="flex flex-col space-y-4 p-4 @md:p-6 @xl:p-10">
     <h1 className="h3 text-base-content/90">Please confirm email</h1>
     <p>
       We&apos;ve sent a confirmation email to the address you entered. Please

--- a/app/(auth)/signup/form.jsx
+++ b/app/(auth)/signup/form.jsx
@@ -30,7 +30,7 @@ export default function SignupForm() {
   })
 
   return (
-    <div className="section-card-inner">
+    <div>
       {submitSignup.isSuccess ? (
         <SuccessfulSubmit />
       ) : (

--- a/app/(auth)/signup/page.jsx
+++ b/app/(auth)/signup/page.jsx
@@ -2,7 +2,7 @@ import SignupForm from './form'
 
 export default function Page() {
   return (
-    <main className="section-card">
+    <main className="card card-body bg-base-100 text-base-content">
       <SignupForm />
     </main>
   )

--- a/app/(auth)/signup/page.jsx
+++ b/app/(auth)/signup/page.jsx
@@ -2,7 +2,7 @@ import SignupForm from './form'
 
 export default function Page() {
   return (
-    <main className="card card-body bg-base-100 text-base-content">
+    <main className="card-white">
       <SignupForm />
     </main>
   )

--- a/app/components/BigPhrase.jsx
+++ b/app/components/BigPhrase.jsx
@@ -50,7 +50,7 @@ const AddCardButtonsSection = ({ phrase_id, user_deck_id, onClose }) => {
           This phrase is in your deck with status: &ldquo;
           {makeNewCard.data?.status}
           &rdquo;.&nbsp;
-          <a href="#" className="text-primary link" onClick={onClose}>
+          <a className="text-primary link" onClick={onClose}>
             Keep browsing.
           </a>
         </p>

--- a/app/components/Modal.jsx
+++ b/app/components/Modal.jsx
@@ -6,7 +6,7 @@ function MyModal({ onRequestClose, isOpen, children }) {
   return (
     <Modal
       isOpen={isOpen}
-      className="card-white w-app my-6 place-self-center outline-none max-sm:mx-1"
+      className="@container card-white w-app my-6 place-self-center outline-none max-sm:mx-1"
       overlayClassName="bg-black/60 fixed backdrop-blur-sm fixed inset-0 flex"
       noScroll={true}
       onRequestClose={onRequestClose}

--- a/app/components/Modal.jsx
+++ b/app/components/Modal.jsx
@@ -6,7 +6,7 @@ function MyModal({ onRequestClose, isOpen, children }) {
   return (
     <Modal
       isOpen={isOpen}
-      className="big-card my-6 mx-auto w-11/12 place-self-center outline-none"
+      className="card-white w-app my-6 place-self-center outline-none max-sm:mx-1"
       overlayClassName="bg-black/60 fixed backdrop-blur-sm fixed inset-0 flex"
       noScroll={true}
       onRequestClose={onRequestClose}

--- a/app/components/Sidebar.jsx
+++ b/app/components/Sidebar.jsx
@@ -19,11 +19,7 @@ const Navlink = ({ href, children }) => {
       {children}
     </Link>
   ) : (
-    <a
-      href="#"
-      className="border-gray-400 pl-2 border-l-4 text-gray-600"
-      disabled
-    >
+    <a className="border-gray-400 pl-2 border-l-4 text-gray-600" disabled>
       {children}
     </a>
   )

--- a/app/components/edit-status-buttons.jsx
+++ b/app/components/edit-status-buttons.jsx
@@ -32,7 +32,7 @@ export default function EditCardStatusButtons({ cardId }) {
   const isSkipped = card?.status === 'skipped'
   return (
     <>
-      <div className="flex flex-col md:flex-row mx-auto max-w-80 justify-center gap-2 mt-6">
+      <div className="flex flex-col @md:flex-row mx-auto max-w-80 justify-center gap-2 mt-6">
         <button
           onClick={() => updateStatus.mutate({ cardId, status: 'learned' })}
           className={`btn btn-success ${isLearned && 'btn-outline'}`}

--- a/app/getting-started/page.jsx
+++ b/app/getting-started/page.jsx
@@ -119,7 +119,7 @@ export default function Page() {
         </div>
       ) : null}
       <h1 className="d1">Welcome to Sunlo</h1>
-      <div className="max-w-prose">
+      <div className="w-app">
         <p className="text-2xl my-4 mb-10">Let&apos;s get started</p>
         <SetUsernameStep value={tempUsernameToUse} set={setTempUsername} />
         <SetPrimaryLanguageStep

--- a/app/getting-started/page.jsx
+++ b/app/getting-started/page.jsx
@@ -89,8 +89,8 @@ export default function Page() {
   })
 
   return profile === null ? null : mainForm.isSuccess ? (
-    <main className="p2 md:p-6 lg:p-10 max-w-prose text-white min-h-85vh flex flex-col gap-12 justify-center">
-      <div className="flex flex-row justify-center space-x-4">
+    <main className="p2 md:p-6 lg:p-10 w-app text-white min-h-85vh flex flex-col gap-12 justify-center">
+      <div className="flex flex-row justify-center gap-4 place-items-center">
         <SuccessCheckmark />
         <h1 className="h1">You&apos;re all set!</h1>
       </div>
@@ -118,7 +118,7 @@ export default function Page() {
           </Link>
         </div>
       ) : null}
-      <h1 className="d1">Welcome to Sunlo</h1>
+      <h1 className="d1 text-center">Welcome to Sunlo</h1>
       <div className="w-app">
         <p className="text-2xl my-4 mb-10">Let&apos;s get started</p>
         <SetUsernameStep value={tempUsernameToUse} set={setTempUsername} />

--- a/app/getting-started/page.jsx
+++ b/app/getting-started/page.jsx
@@ -118,9 +118,11 @@ export default function Page() {
           </Link>
         </div>
       ) : null}
-      <h1 className="d1 text-center">Welcome to Sunlo</h1>
+      <h1 className="d1 @md:text-center">Welcome to Sunlo</h1>
       <div className="w-app">
-        <p className="text-2xl my-4 mb-10">Let&apos;s get started</p>
+        <p className="text-2xl my-4 mb-10 @md:text-center">
+          Let&apos;s get started
+        </p>
         <SetUsernameStep value={tempUsernameToUse} set={setTempUsername} />
         <SetPrimaryLanguageStep
           value={tempLanguagePrimaryToUse}

--- a/app/getting-started/page.jsx
+++ b/app/getting-started/page.jsx
@@ -164,7 +164,7 @@ const SetPrimaryLanguageStep = ({ value, set }) => {
     </Completed>
   ) : (
     <form
-      className="big-card mb-16"
+      className="card-white mb-16"
       onSubmit={e => {
         e.preventDefault()
         setClosed(true)
@@ -242,7 +242,7 @@ const CreateFirstDeckStep = ({ value, set }) => {
       />
     </Completed>
   ) : (
-    <form className="big-card mb-16">
+    <form className="card-white mb-16">
       <h2 className="h2">
         Create {decks?.length === 0 ? 'your first deck' : 'another deck'}
       </h2>
@@ -298,7 +298,7 @@ const SetUsernameStep = ({ value, set }) => {
     </Completed>
   ) : (
     <form
-      className="big-card mb-16"
+      className="card-white mb-16"
       onSubmit={e => {
         e.preventDefault()
         if (e.target.username.value) setClosed(true)

--- a/app/getting-started/page.jsx
+++ b/app/getting-started/page.jsx
@@ -4,6 +4,7 @@ import { useState } from 'react'
 import { useMutation } from '@tanstack/react-query'
 import { useAuth } from 'lib/auth-context'
 import supabase from 'lib/supabase-client'
+import Navbar from 'app/(app)/Navbar'
 import ErrorList from 'app/components/ErrorList'
 import Link from 'next/link'
 import { useProfile } from 'app/data/hooks'
@@ -110,48 +111,44 @@ export default function Page() {
       </div>
     </main>
   ) : (
-    <main className="text-white p2 md:p-6 lg:p-10">
-      {profile ? (
-        <div className="absolute top-4 md:top-10">
-          <Link href="/profile" className="link md:link-hover">
-            &larr; Back to profile
-          </Link>
-        </div>
-      ) : null}
-      <h1 className="d1 @md:text-center">Welcome to Sunlo</h1>
-      <div className="w-app">
-        <p className="text-2xl my-4 mb-10 @md:text-center">
-          Let&apos;s get started
-        </p>
-        <SetUsernameStep value={tempUsernameToUse} set={setTempUsername} />
-        <SetPrimaryLanguageStep
-          value={tempLanguagePrimaryToUse}
-          set={setTempLanguagePrimary}
-        />
-        <CreateFirstDeckStep value={tempDeckToAdd} set={setTempDeckToAdd} />
+    <>
+      <Navbar>&nbsp;</Navbar>
+      <main className="text-white p2 md:p-6 lg:p-10">
+        <h1 className="d1 @md:text-center">Welcome to Sunlo</h1>
+        <div className="w-app">
+          <p className="text-2xl my-4 mb-10 @md:text-center">
+            Let&apos;s get started
+          </p>
+          <SetUsernameStep value={tempUsernameToUse} set={setTempUsername} />
+          <SetPrimaryLanguageStep
+            value={tempLanguagePrimaryToUse}
+            set={setTempLanguagePrimary}
+          />
+          <CreateFirstDeckStep value={tempDeckToAdd} set={setTempDeckToAdd} />
 
-        {tempLanguagePrimaryToUse &&
-        (tempDeckToAdd || profile.deck_stubs?.length > 0) &&
-        tempUsernameToUse ? (
-          <div className="my-6 flex flex-row-reverse justify-around items-center">
-            <button
-              onClick={mainForm.mutate}
-              className="btn btn-accent md:btn-lg"
-              disabled={mainForm.isSubmitting}
-            >
-              Confirm and get started!
-            </button>
-            <button onClick={reset} className="btn btn-primary">
-              Reset page
-            </button>
-          </div>
-        ) : null}
-      </div>
-      <ErrorList
-        summary="Problem inserting profile or making deck"
-        error={mainForm.error}
-      />
-    </main>
+          {tempLanguagePrimaryToUse &&
+          (tempDeckToAdd || profile.deck_stubs?.length > 0) &&
+          tempUsernameToUse ? (
+            <div className="my-6 flex flex-row-reverse justify-around items-center">
+              <button
+                onClick={mainForm.mutate}
+                className="btn btn-accent md:btn-lg"
+                disabled={mainForm.isSubmitting}
+              >
+                Confirm and get started!
+              </button>
+              <button onClick={reset} className="btn btn-primary">
+                Reset page
+              </button>
+            </div>
+          ) : null}
+        </div>
+        <ErrorList
+          summary="Problem inserting profile or making deck"
+          error={mainForm.error}
+        />
+      </main>
+    </>
   )
 }
 

--- a/app/language/[lang]/page.jsx
+++ b/app/language/[lang]/page.jsx
@@ -28,7 +28,7 @@ export default async function Page({ params: { lang } }) {
           But you can be the first to add one!
         </p>
       ) : (
-        <ul className="columns-1 sm:columns-2 lg:columns-3 gap-4">
+        <ul className="columns-1 @lg:columns-2 @3xl:columns-3 gap-4">
           {language.phrases.map(phrase => (
             <li key={`phrase-${phrase.id}`}>
               <Link href={`/phrase/${phrase.id}`}>

--- a/app/language/page.jsx
+++ b/app/language/page.jsx
@@ -5,7 +5,7 @@ export default async function Page() {
   return (
     <main className="page-card">
       <h1 className="h1">Languages</h1>
-      <ul className="columns-1 sm:columns-2 lg:columns-3 gap-4">
+      <ul className="columns-1 @lg:columns-2 @3xl:columns-3 gap-4">
         {Object.keys(languages).map(lang => (
           <li key={lang}>
             <Link href={`/language/${lang}`} className="btn btn-ghost">

--- a/app/layout.jsx
+++ b/app/layout.jsx
@@ -35,18 +35,16 @@ export default function RootLayout({ children }) {
                 business happens in a consistent sizing box, no matter the
                 contents on screen at the time.
               */}
-              <div className="@container w-full py-4">
+              <div className="@container w-full py-8">
                 <div
                   className="
                     w-[98cqw] max-w-[900px] px-[1cqw]
                     mx-auto
                     min-h-screen
                     flex flex-col
-                    justify-center
                   "
                 >
                   {children}
-                  
                 </div>
               </div>
             </div>

--- a/app/layout.jsx
+++ b/app/layout.jsx
@@ -18,18 +18,17 @@ export default function RootLayout({ children }) {
   return (
     <html lang="en">
       <body className="bg-primary text-white flex flex-row min-h-screen">
+        {/*
+          This is the root of the layout. The flex, with 2 children
+          a) Sidebar with fixed width, and b) and main content/app area. 
+          This flex allows the sidebar to shift the content right.
+        */}
         <Toaster />
         <QueryProvider>
           <AuthProvider>
-            {/*
-              This is the root of the layout. The flex, with 2 children
-              a) Sidebar with fixed width, and b) and main content/app area
-              with .flex-grow
-            */}
             <Sidebar />
             {/*
-              This is the main container for the app. Its child applies some
-              container-relative padding and width, ensuring that the app's
+              This is the main container for the site, ensuring that all the
               business happens in a consistent sizing box, no matter the
               contents on screen at the time.
             */}
@@ -38,7 +37,6 @@ export default function RootLayout({ children }) {
                 @container w-full max-w-[1100px] 
                 py-20 
                 mx-auto px-[1%]
-                flex flex-col
               "
             >
               {children}

--- a/app/layout.jsx
+++ b/app/layout.jsx
@@ -17,37 +17,33 @@ export const viewport = {
 export default function RootLayout({ children }) {
   return (
     <html lang="en">
-      <body className="bg-primary text-white">
+      <body className="bg-primary text-white flex flex-row min-h-screen">
         <Toaster />
         <QueryProvider>
           <AuthProvider>
-            <div id="modal-root" />
             {/*
               This is the root of the layout. The flex, with 2 children
               a) Sidebar with fixed width, and b) and main content/app area
               with .flex-grow
             */}
-            <div className="flex min-h-screen">
-              <Sidebar />
-              {/*
-                This is the main container for the app. Its child applies some
-                container-relative padding and width, ensuring that the app's
-                business happens in a consistent sizing box, no matter the
-                contents on screen at the time.
-              */}
-              <div className="@container w-full py-8">
-                <div
-                  className="
-                    w-[98cqw] max-w-[900px] px-[1cqw]
-                    mx-auto
-                    min-h-screen
-                    flex flex-col
-                  "
-                >
-                  {children}
-                </div>
-              </div>
+            <Sidebar />
+            {/*
+              This is the main container for the app. Its child applies some
+              container-relative padding and width, ensuring that the app's
+              business happens in a consistent sizing box, no matter the
+              contents on screen at the time.
+            */}
+            <div
+              className="
+                @container w-full max-w-[1100px] 
+                py-20 
+                mx-auto px-[1%]
+                flex flex-col
+              "
+            >
+              {children}
             </div>
+            <div id="modal-root" />
           </AuthProvider>
         </QueryProvider>
       </body>

--- a/app/layout.jsx
+++ b/app/layout.jsx
@@ -12,6 +12,7 @@ export const metadata = {
 
 export const viewport = {
   themeColor: '#570df8',
+  viewportFit: 'cover',
 }
 
 export default function RootLayout({ children }) {
@@ -23,7 +24,7 @@ export default function RootLayout({ children }) {
           a) Sidebar with fixed width, and b) and main content/app area. 
           This flex allows the sidebar to shift the content right.
         */}
-        <Toaster />
+        <Toaster position="bottom-center" />
         <QueryProvider>
           <AuthProvider>
             <Sidebar />

--- a/app/page.jsx
+++ b/app/page.jsx
@@ -4,7 +4,7 @@ import { GarlicBroccoli } from 'app/components/Garlic'
 export default function Page() {
   return (
     <>
-      <main className="flex flex-row flex-wrap gap-4 justify-around">
+      <main className="flex flex-row flex-wrap gap-4 my-20">
         <article className="space-y-4 flex flex-col basis-11/12 sm:basis-3/5 justify-center">
           <h1 className="text-4xl">
             Sunlo is a social
@@ -27,7 +27,7 @@ export default function Page() {
         </aside>
       </main>
 
-      <div className="fixed top-0 left-0 h-20 right-0 bg-black/70 text-warning">
+      <div className="max-w-prose mx-auto bg-black/70 text-warning">
         <p className="md:container md:max-w-[70vw] p-4 text-center">
           ⚠️ Sunlo is under development; it is very incomplete but most of
           what&apos;s there should work so if you do spot a problem, please let

--- a/app/page.jsx
+++ b/app/page.jsx
@@ -4,19 +4,19 @@ import { GarlicBroccoli } from 'app/components/Garlic'
 export default function Page() {
   return (
     <>
-      <main className="flex flex-row flex-wrap gap-4 mb-8 sm:my-20">
-        <article className="space-y-4 flex flex-col basis-11/12 sm:basis-3/5 justify-center mx-auto max-w-[537px]">
-          <h1 className="text-4xl max-sm:text-center sm:h-24 sm:mt-12 md:mt-16">
+      <main className="flex flex-row flex-wrap gap-4 mb-8 @xl:my-20">
+        <article className="space-y-4 flex flex-col basis-11/12 @xl:basis-3/5 justify-center mx-auto max-w-[537px]">
+          <h1 className="text-4xl text-center @xl:text-start @xl:h-24 @xl:mt-16">
             Sunlo is a social
             <br />
             language&nbsp;learning app
           </h1>
-          <p className="text-xl sm:h-[120px] max-sm:text-center">
+          <p className="text-xl @xl:h-[120px] text-center @xl:text-start">
             Create your own flash cards, pick from a crowd-sourced pool, or send
             your friend some key phrases to help them learn.
           </p>
         </article>
-        <aside className="space-y-4 sm:basis-1/3 flex-none text-center max-sm:mx-auto">
+        <aside className="space-y-4 @xl:basis-1/3 flex-none text-center mx-auto">
           <GarlicBroccoli className="mx-auto" />
           <Link
             href="/login"
@@ -27,7 +27,7 @@ export default function Page() {
         </aside>
       </main>
 
-      <div className="w-app md:max-w-[70cqw] bg-black/60 text-warning">
+      <div className="w-app bg-black/60 text-warning">
         <p className="p-4 text-center">
           ⚠️ Sunlo is under development; it is very incomplete but most of
           what&apos;s there should work so if you do spot a problem, please let

--- a/app/page.jsx
+++ b/app/page.jsx
@@ -4,20 +4,20 @@ import { GarlicBroccoli } from 'app/components/Garlic'
 export default function Page() {
   return (
     <>
-      <main className="flex flex-row flex-wrap gap-4 my-20">
-        <article className="space-y-4 flex flex-col basis-11/12 sm:basis-3/5 justify-center">
-          <h1 className="text-4xl">
+      <main className="flex flex-row flex-wrap gap-4 mb-8 sm:my-20">
+        <article className="space-y-4 flex flex-col basis-11/12 sm:basis-3/5 justify-center mx-auto max-w-[537px]">
+          <h1 className="text-4xl mt-8 max-sm:text-center sm:h-24 sm:mt-12 md:mt-16">
             Sunlo is a social
             <br />
             language&nbsp;learning app
           </h1>
-          <p className="text-xl">
+          <p className="text-xl sm:h-[120px] max-sm:text-center">
             Create your own flash cards, pick from a crowd-sourced pool, or send
             your friend some key phrases to help them learn.
           </p>
         </article>
-        <aside className="space-y-4 sm:basis-1/3 flex-none text-center">
-          <GarlicBroccoli />
+        <aside className="space-y-4 sm:basis-1/3 flex-none text-center max-sm:mx-auto">
+          <GarlicBroccoli className="mx-auto" />
           <Link
             href="/login"
             className="btn btn-lg btn-outline btn-primary bg-white"
@@ -27,8 +27,8 @@ export default function Page() {
         </aside>
       </main>
 
-      <div className="max-w-prose mx-auto bg-black/70 text-warning">
-        <p className="md:container md:max-w-[70vw] p-4 text-center">
+      <div className="w-app bg-black/60 text-warning">
+        <p className="md:max-w-[70cqw] p-4 text-center">
           ⚠️ Sunlo is under development; it is very incomplete but most of
           what&apos;s there should work so if you do spot a problem, please let
           me know! ⚠️

--- a/app/page.jsx
+++ b/app/page.jsx
@@ -20,7 +20,7 @@ export default function Page() {
           <GarlicBroccoli className="mx-auto" />
           <Link
             href="/login"
-            className="btn btn-lg btn-outline btn-primary bg-white"
+            className="btn btn-lg btn-primary btn-outline bg-white"
           >
             Log in or sign up &rarr;
           </Link>

--- a/app/page.jsx
+++ b/app/page.jsx
@@ -6,7 +6,7 @@ export default function Page() {
     <>
       <main className="flex flex-row flex-wrap gap-4 mb-8 sm:my-20">
         <article className="space-y-4 flex flex-col basis-11/12 sm:basis-3/5 justify-center mx-auto max-w-[537px]">
-          <h1 className="text-4xl mt-8 max-sm:text-center sm:h-24 sm:mt-12 md:mt-16">
+          <h1 className="text-4xl max-sm:text-center sm:h-24 sm:mt-12 md:mt-16">
             Sunlo is a social
             <br />
             language&nbsp;learning app
@@ -27,8 +27,8 @@ export default function Page() {
         </aside>
       </main>
 
-      <div className="w-app bg-black/60 text-warning">
-        <p className="md:max-w-[70cqw] p-4 text-center">
+      <div className="w-app md:max-w-[70cqw] bg-black/60 text-warning">
+        <p className="p-4 text-center">
           ⚠️ Sunlo is under development; it is very incomplete but most of
           what&apos;s there should work so if you do spot a problem, please let
           me know! ⚠️

--- a/app/profile/avatar-section.jsx
+++ b/app/profile/avatar-section.jsx
@@ -1,13 +1,10 @@
 'use client'
 
 import Image from 'next/image'
-import Link from 'next/link'
 import { useProfile } from 'app/data/hooks'
-import { usePathname } from 'next/navigation'
 
 export default function AvatarSection() {
   const { data: profile } = useProfile()
-  const pathname = usePathname()
   return (
     <header className="text-center my-4 max-w-sm mx-auto">
       <div className="avatar relative">
@@ -27,17 +24,6 @@ export default function AvatarSection() {
       </div>
       <div>
         <h2 className="text-4xl">Hello {profile?.username} 👋</h2>
-        <p className="my-4">
-          {pathname === '/profile' ? (
-            <Link href="/getting-started" className="link md:link-hover">
-              Go to profile setup &rarr;
-            </Link>
-          ) : (
-            <Link href="/profile" className="link md:link-hover">
-              &larr; Back to profile
-            </Link>
-          )}
-        </p>
       </div>
     </header>
   )

--- a/app/profile/change-email-success/page.jsx
+++ b/app/profile/change-email-success/page.jsx
@@ -5,7 +5,7 @@ import { useAuth } from 'lib/auth-context'
 export default function Page() {
   const { userEmail } = useAuth()
   return (
-    <main className="card card-body bg-base-100 text-base-content">
+    <main className="card card-body bg-base-100 text-base-content max-w-lg mx-auto">
       {userEmail ? (
         <div className="flex flex-col space-y-4">
           <h1 className="h3 text-base-content/90">Email address changed!</h1>

--- a/app/profile/change-email-success/page.jsx
+++ b/app/profile/change-email-success/page.jsx
@@ -5,7 +5,7 @@ import { useAuth } from 'lib/auth-context'
 export default function Page() {
   const { userEmail } = useAuth()
   return (
-    <main className="section-card">
+    <main className="card card-body bg-base-100 text-base-content">
       {userEmail ? (
         <div className="flex flex-col space-y-4">
           <h1 className="h3 text-base-content/90">Email address changed!</h1>

--- a/app/profile/change-email-success/page.jsx
+++ b/app/profile/change-email-success/page.jsx
@@ -1,26 +1,30 @@
 'use client'
 
 import { useAuth } from 'lib/auth-context'
+import Navbar from 'app/(app)/Navbar'
 
 export default function Page() {
   const { userEmail } = useAuth()
   return (
-    <main className="card card-body bg-base-100 text-base-content max-w-lg mx-auto">
-      {userEmail ? (
-        <div className="flex flex-col space-y-4">
-          <h1 className="h3 text-base-content/90">Email address changed!</h1>
-          <p>You&apos;ve successfully changed your email to {userEmail}</p>
-          <p>You can close this tab.</p>
-        </div>
-      ) : (
-        <div className="flex flex-col space-y-4">
-          <h1 className="h3 text-base-content/90">Something went wrong...</h1>
-          <p>
-            We are&apos;t sure what it is... if this message is still here in 10
-            seconds you may want to try setting your email again.
-          </p>
-        </div>
-      )}
-    </main>
+    <>
+      <Navbar title="Email changed" />
+      <main className="card-white w-4/5 mx-auto">
+        {userEmail ? (
+          <div className="flex flex-col space-y-4">
+            <h1 className="h3 text-base-content/90">Email address changed!</h1>
+            <p>You&apos;ve successfully changed your email to {userEmail}</p>
+            <p>You can close this tab.</p>
+          </div>
+        ) : (
+          <div className="flex flex-col space-y-4">
+            <h1 className="h3 text-base-content/90">Something went wrong...</h1>
+            <p>
+              We are&apos;t sure what it is... if this message is still here in
+              10 seconds you may want to try setting your email again.
+            </p>
+          </div>
+        )}
+      </main>
+    </>
   )
 }

--- a/app/profile/change-email/form.jsx
+++ b/app/profile/change-email/form.jsx
@@ -25,7 +25,7 @@ export default function SetNewEmailForm() {
   })
 
   return (
-    <div className="section-card-inner">
+    <>
       {changeEmail.isSuccess ? (
         <SuccessfulSubmit />
       ) : (
@@ -75,7 +75,7 @@ export default function SetNewEmailForm() {
           />
         </>
       )}
-    </div>
+    </>
   )
 }
 

--- a/app/profile/change-email/page.jsx
+++ b/app/profile/change-email/page.jsx
@@ -2,7 +2,7 @@ import SetNewEmailForm from './form'
 
 export default function Page() {
   return (
-    <main className="section-card">
+    <main className="card card-body bg-base-100 text-base-content">
       <SetNewEmailForm />
     </main>
   )

--- a/app/profile/change-email/page.jsx
+++ b/app/profile/change-email/page.jsx
@@ -2,7 +2,7 @@ import SetNewEmailForm from './form'
 
 export default function Page() {
   return (
-    <main className="card card-body bg-base-100 text-base-content">
+    <main className="card card-body bg-base-100 text-base-content max-w-lg mx-auto">
       <SetNewEmailForm />
     </main>
   )

--- a/app/profile/change-email/page.jsx
+++ b/app/profile/change-email/page.jsx
@@ -5,7 +5,7 @@ export default function Page() {
   return (
     <>
       <Navbar title="Change email" />
-      <main className="card card-body bg-base-100 text-base-content mx-auto w-4/5">
+      <main className="card-white mx-auto w-4/5">
         <SetNewEmailForm />
       </main>
     </>

--- a/app/profile/change-email/page.jsx
+++ b/app/profile/change-email/page.jsx
@@ -1,9 +1,13 @@
+import Navbar from 'app/(app)/Navbar'
 import SetNewEmailForm from './form'
 
 export default function Page() {
   return (
-    <main className="card card-body bg-base-100 text-base-content max-w-lg mx-auto">
-      <SetNewEmailForm />
-    </main>
+    <>
+      <Navbar title="Change email" />
+      <main className="card card-body bg-base-100 text-base-content mx-auto w-4/5">
+        <SetNewEmailForm />
+      </main>
+    </>
   )
 }

--- a/app/profile/change-password/page.jsx
+++ b/app/profile/change-password/page.jsx
@@ -2,7 +2,7 @@ import SetNewPasswordForm from 'app/(auth)/set-new-password/form'
 
 export default function Page() {
   return (
-    <main className="section-card">
+    <main className="card card-body bg-base-100 text-base-content">
       <SetNewPasswordForm />
     </main>
   )

--- a/app/profile/change-password/page.jsx
+++ b/app/profile/change-password/page.jsx
@@ -2,7 +2,7 @@ import SetNewPasswordForm from 'app/(auth)/set-new-password/form'
 
 export default function Page() {
   return (
-    <main className="card card-body bg-base-100 text-base-content">
+    <main className="card card-body bg-base-100 text-base-content max-w-lg mx-auto">
       <SetNewPasswordForm />
     </main>
   )

--- a/app/profile/change-password/page.jsx
+++ b/app/profile/change-password/page.jsx
@@ -1,9 +1,13 @@
+import Navbar from 'app/(app)/Navbar'
 import SetNewPasswordForm from 'app/(auth)/set-new-password/form'
 
 export default function Page() {
   return (
-    <main className="card card-body bg-base-100 text-base-content max-w-lg mx-auto">
-      <SetNewPasswordForm />
-    </main>
+    <>
+      <Navbar title="Change password" />
+      <main className="card-white w-4/5 mx-auto">
+        <SetNewPasswordForm />
+      </main>
+    </>
   )
 }

--- a/app/profile/layout.jsx
+++ b/app/profile/layout.jsx
@@ -2,7 +2,7 @@ import AvatarSection from './avatar-section'
 
 export default function Layout({ children }) {
   return (
-    <div className="w-app space-y-4">
+    <div className="w-app flex flex-col gap-4">
       <AvatarSection />
       {children}
     </div>

--- a/app/profile/layout.jsx
+++ b/app/profile/layout.jsx
@@ -2,7 +2,7 @@ import AvatarSection from './avatar-section'
 
 export default function Layout({ children }) {
   return (
-    <div className="max-w-prose mx-auto space-y-4">
+    <div className="w-app space-y-4">
       <AvatarSection />
       {children}
     </div>

--- a/app/profile/page.jsx
+++ b/app/profile/page.jsx
@@ -1,8 +1,10 @@
+import Navbar from 'app/(app)/Navbar'
 import { ProfileCard, UserAuthCard } from './client'
 
 export default function Page() {
   return (
     <>
+      <Navbar title={`Your profile`} />
       <ProfileCard />
       <UserAuthCard />
     </>

--- a/app/profile/page.jsx
+++ b/app/profile/page.jsx
@@ -1,10 +1,13 @@
+import Link from 'next/link'
 import Navbar from 'app/(app)/Navbar'
 import { ProfileCard, UserAuthCard } from './client'
 
 export default function Page() {
   return (
     <>
-      <Navbar title={`Your profile`} />
+      <Navbar>
+        <Link href="/getting-started">Profile setup &rarr;</Link>
+      </Navbar>
       <ProfileCard />
       <UserAuthCard />
     </>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -32,20 +32,16 @@
   .link {
     @apply hover:underline cursor-pointer;
   }
-  /* used when you want a big card area, that goes as wide as prose */
-  .big-card {
-    @apply card bg-base-100 text-base-content p-6 border shadow-lg mb-6 w-app;
+  .card-white {
+    @apply card card-body bg-base-100 text-base-content;
   }
   /* used for a whole page */
   .page-card {
-    @apply container card border shadow-lg bg-base-100 text-base-content px-3 md:px-6 lg:px-10 mb-6 pt-10 pb-16 mx-auto;
+    @apply card-white;
   }
   .page-card > .h1,
   .page-card > .h2 {
     @apply mb-8 text-base-content/90;
-  }
-  .card-white {
-    @apply card bg-base-100 text-base-content;
   }
 }
 @layer utilities {

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -27,7 +27,7 @@
 
 @layer components {
   .w-app {
-    @apply w-full max-w-[40rem] mx-auto;
+    @apply w-full max-w-[40rem] mx-auto; /* outline outline-dashed outline-white/50; */
   }
   .link {
     @apply hover:underline cursor-pointer;

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -26,12 +26,15 @@
 }
 
 @layer components {
+  .w-app {
+    @apply w-full max-w-[40rem] mx-auto;
+  }
   .link {
     @apply hover:underline cursor-pointer;
   }
   /* used when you want a big card area, that goes as wide as prose */
   .big-card {
-    @apply card bg-base-100 text-base-content p-6 border shadow-lg mb-6 max-w-prose;
+    @apply card bg-base-100 text-base-content p-6 border shadow-lg mb-6 w-app;
   }
   /* used for a whole page */
   .page-card {

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -31,12 +31,12 @@
   }
   /* used when you want a card section, width lg */
   .section-card {
-    @apply card mx-auto shadow-lg bg-base-100 text-base-content max-w-lg p-10;
+    @apply card mx-auto shadow-lg bg-base-100 text-base-content max-w-lg p-4;
   }
   /* used inside .section-card to provide optional spacing and 
   ability to use the section inside other elements */
   .section-card-inner {
-    @apply max-w-lg md:px-4 lg:px-8;
+    @apply md:px-4 lg:px-8 gap-8;
   }
   /* used when you want a big card area, that goes as wide as prose */
   .big-card {
@@ -68,7 +68,7 @@
     @apply lg:text-4xl md:text-3xl text-2xl my-4; /* font-display;*/
   }
   .h3 {
-    @apply md:text-2xl text-xl my-3; /* font-display;*/
+    @apply md:text-2xl text-xl mt-1 mb-3; /* font-display;*/
   }
   .h4 {
     @apply md:text-xl text-lg my-2; /* font-display;*/

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -23,6 +23,11 @@
     --tab-radius:0.5rem;
     */
   }
+  body,
+  #sidebar-all nav {
+    padding-top: env(safe-area-inset-top);
+    padding-bottom: env(safe-area-inset-bottom);
+  }
 }
 
 @layer components {

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -29,15 +29,6 @@
   .link {
     @apply hover:underline cursor-pointer;
   }
-  /* used when you want a card section, width lg */
-  .section-card {
-    @apply card mx-auto shadow-lg bg-base-100 text-base-content max-w-lg p-4;
-  }
-  /* used inside .section-card to provide optional spacing and 
-  ability to use the section inside other elements */
-  .section-card-inner {
-    @apply md:px-4 lg:px-8 gap-8;
-  }
   /* used when you want a big card area, that goes as wide as prose */
   .big-card {
     @apply card bg-base-100 text-base-content p-6 border shadow-lg mb-6 max-w-prose;


### PR DESCRIPTION
This PR is primarily about adding a Navbar that will make the app more usable on mobiles or other devices where the device/browser itself doesn't provide a back button and we need to provide these affordances in the app itself.

When I added Tauri (#70), I got to use the site as a native app on Android and iOS, and realized that the content kinda jumps around and there's no back button! And thus the navbar project was born. So instead of taking a "center everything on every axis" approach, we're adding a consistent nav-bar with an in-app back button, a title that's in the same place and the same size on every page, and an option to add a content menu or a link (e.g. on the dark page, an "add card" link). 

The <Navbar> is just a simple component which by convention we render once in each Page component. I considered using [a route slot catch-all layout page like this example from NextJS docs](https://nextjs.org/docs/app/api-reference/functions/use-selected-layout-segments), it just seemed easier to kind of copy and paste the component onto each page that needed it, and this way we can pass data from the page to the title, e.g. "1 out of 15 cards". 

For the moment, the top-left button is always just "Back" and instead of the context menu we just have {children} so the page can pass whatever link or menu it wants, like an "add deck" button or the "new card" component that opens the modal to add a new card. Interestingly, the context menu might be the thing that gives me a reason to use [the layout approach](https://nextjs.org/docs/app/building-your-application/routing/parallel-routes#tab-groups), because you can kind of keep adding menu sections to the top.

To do the navbar responsively, I added a container and used tailwind's container query utilities, and while I was doing that it kind of opened a whole can of worms about really making the app feel like an "App", with consistent navigation and discoverability of user actions, and more consistency in the placement and spacing of the contents of different pages. So since I was touching all this stuff anyway I:
* changed some `vw`s over to `cqw`s and changed some `text-white` to `text-base-100` etc
* created a class `w-app` to apply to layouts and main items to constrain the contents of the page to a kind of "app shaped" box which centers itself and maintains size regardless of contents
* the RootLayout is much simpler and more of just a consistent shell
* stop using some custom styles like some of these buttons
* retire the `big-card` class altogether in favor of `card-white` which now does all the same things by applying daisy's built-in card classes

It was good and the degree of scope creep was okay but it was also a ton of yak shaving and I am tired now 😪 
