### PR TITLE
Add homepage content

### DIFF
--- a/app/page.jsx
+++ b/app/page.jsx
@@ -6,10 +6,8 @@ export default function Page() {
     <>
       <main className="flex flex-row flex-wrap gap-4 mb-8 @xl:my-20">
         <div className="space-y-4 flex flex-col basis-11/12 @xl:basis-3/5 justify-center mx-auto max-w-[537px]">
-          <h1 className="text-4xl text-center @xl:text-start @xl:h-24 @xl:mt-16">
-            Sunlo is a social
-            <br />
-            language&nbsp;learning app
+          <h1 className="d2 text-center @xl:text-start mt-12 md:mb-10 @xl:mt-8 @xl:mb-4">
+            Sunlo: social language&nbsp;learning
           </h1>
           <p className="text-xl @xl:h-[120px] text-center @xl:text-start">
             Create your own flash cards, pick from a crowd-sourced pool, or send
@@ -35,14 +33,11 @@ export default function Page() {
           me know! ⚠️
         </p>
       </div>
-      <section
-        data-theme="light"
-        className="card my-16 pt-4 @lg:pt-10 pb-8 @lg:pb-16 px-1 @lg:px-4"
-      >
+      <section className="card my-16 pt-4 @lg:pt-10 pb-8 @lg:pb-16 px-1 @lg:px-4 bg-base-100 text-base-content">
         <h2 className="h2 text-center px-4 @lg:pb-6">
           Our Approach to Language&nbsp;Learning
         </h2>
-        <div className="flex flex-col @lg:flex-row justify-center gap-4">
+        <div className="flex flex-col @xl:flex-row justify-center gap-4">
           <div className="card bg-base-200 basis-80 shadow-xl">
             <div className="card-body">
               <h3 className="card-title">
@@ -99,7 +94,7 @@ export default function Page() {
       </section>
       <section className="my-16 pt-4 @lg:pt-10 pb-16">
         <h2 className="h2 text-center px-4 pb-6">Who is Sunlo for?</h2>
-        <div className="flex flex-col @lg:flex-row justify-center gap-4">
+        <div className="flex flex-col @xl:flex-row justify-center gap-4">
           <div className="card bg-black/20 basis-80 shadow-xl">
             <div className="card-body">
               <h3 className="card-title">
@@ -165,10 +160,7 @@ export default function Page() {
         </Link>
       </section>
 
-      <section
-        data-theme="light"
-        className="card my-16 pt-4 @lg:pt-10 pb-16 px-4 @lg:px-8"
-      >
+      <section className="card my-16 pt-4 @lg:pt-10 pb-16 px-4 @lg:px-8 bg-base-100 text-base-content">
         <h2 className="h2 text-center px-4 pb-6">The Story Behind Sunlo</h2>
         <div className="columns-1 @lg:columns-2 space-y-4 text-xl/8">
           <p>
@@ -254,9 +246,9 @@ export default function Page() {
         </h2>
         <div className="columns-1 @xl:columns-3 @lg:columns-2 space-y-4 text-xl/8">
           <p>
-            For now Sunlo is just
-            me, trying to learn languages to connect with the people I love. It
-            is my humble wish that it may help others do the same 🙏
+            For now Sunlo is just me, trying to learn languages to connect with
+            the people I love. It is my humble wish that it may help others do
+            the same 🙏
           </p>
           <p>
             If you have feedback or suggestions or requests, please do get in
@@ -264,8 +256,8 @@ export default function Page() {
             get better! ❤️
           </p>
           <p>
-            If you&apos;re a developer or a language
-            expert and would like to help,{' '}
+            If you&apos;re a developer or a language expert and would like to
+            help,{' '}
             <a
               className="link decoration-white/50 hover:decoration-white"
               href="https://github.com/michaelsnook/sunlo-nextjs"

--- a/app/page.jsx
+++ b/app/page.jsx
@@ -297,6 +297,9 @@ export default function Page() {
         >
           <CodeIcon /> &nbsp;GitHub
         </a>
+        <Link className="btn btn-ghost" href="/privacy-policy">
+          <PencilIcon /> &nbsp;Privacy Policy
+        </Link>
         <Link className="btn btn-ghost" href="/login">
           <LoginIcon /> &nbsp;Login
         </Link>

--- a/app/page.jsx
+++ b/app/page.jsx
@@ -31,10 +31,367 @@ export default function Page() {
       <div className="w-app bg-black/30 text-warning alert">
         <p className="text-center">
           ⚠️ Sunlo is under development; it is incomplete but most of
-          what&apos;s there should work, so if you do spot a problem, please let
+          what&apos;s here should work, so if you do spot a problem, please let
           me know! ⚠️
         </p>
       </div>
+      <section
+        data-theme="light"
+        className="card my-16 pt-4 @lg:pt-10 pb-8 @lg:pb-16 px-1 @lg:px-4"
+      >
+        <h2 className="h2 text-center px-4 @lg:pb-6">
+          Our Approach to Language&nbsp;Learning
+        </h2>
+        <div className="flex flex-col @lg:flex-row justify-center gap-4">
+          <div className="card bg-base-200 basis-80 shadow-xl">
+            <div className="card-body">
+              <h3 className="card-title">
+                <PhraseIcon /> Phrase Based
+              </h3>
+              <p>
+                Sunlo&apos;s approach is phrases-first, useful for people who
+                are immersed in a new language context and want to learn for
+                immediate use – how to ask for directions or order tea or swear
+                at your friends.
+              </p>
+              <p>
+                We think this is effective, and motivating – and it means you
+                can choose the areas you focus on to suit your goals.
+              </p>
+            </div>
+          </div>
+          <div className="card bg-base-200 basis-80 shadow-xl">
+            <div className="card-body">
+              <h3 className="card-title">
+                <SocialIcon /> Social Learning
+              </h3>
+              <p>
+                We don&apos;t learn languages to earn gems or score points – we
+                learn to connect with people.
+              </p>
+              <p>
+                When you move to a new city, take a new job, or want to learn
+                the language of your extended family, you will always find
+                people who want to help, which is why Sunlo has a special
+                &ldquo;Friend Mode&rdquo; so your new friends can send you all
+                their favourite phrases and help you along your journey.
+              </p>
+            </div>
+          </div>
+          <div className="card bg-base-200 basis-80 shadow-xl">
+            <div className="card-body">
+              <h3 className="card-title">
+                <CuriosityIcon /> Driven by Curiosity
+              </h3>
+              <p>
+                Often times, trying to translate directly from one language to
+                another doesn&apos;t really work, but if you spend enough time
+                clicking around you will start to catch on to the patterns.
+              </p>
+              <p>
+                Sunlo is meant to feed your curiosity and reward it, because
+                that feeling of wonder and excitement keeps your brain in its
+                best learning space.
+              </p>
+            </div>
+          </div>
+        </div>
+      </section>
+      <section className="my-16 pt-4 @lg:pt-10 pb-16">
+        <h2 className="h2 text-center px-4 pb-6">Who is Sunlo for?</h2>
+        <div className="flex flex-col @lg:flex-row justify-center gap-4">
+          <div className="card bg-black/20 basis-80 shadow-xl">
+            <div className="card-body">
+              <h3 className="card-title">
+                <PlaneIcon />
+                Moving To a New Place
+              </h3>
+              <p>
+                If you just moved to a new place, and you&apos;re surrounded by
+                people speaking another language, Sunlo is for you.
+              </p>
+              <p>
+                Our approach works best when you have daily opportunities to
+                deploy your new skills and build on them – and when you have
+                friends, family or colleagues who are excited to help you learn.
+              </p>
+            </div>
+          </div>
+          <div className="card bg-black/20 basis-80 shadow-xl">
+            <div className="card-body">
+              <h3 className="card-title">
+                <FriendIcon /> The Friend / Guide
+              </h3>
+              <p>
+                If you&apos;re the one helping a friend or colleague learn{' '}
+                <em>your</em> language, Sunlo&apos;s &ldquo;Friend Mode&rdquo;
+                is for you! Teach them the lyrics to a favourite song, or how to
+                order at lunch for the table.
+              </p>
+              <p>
+                You can pick from our public pool of flash cards, or create new
+                ones that will help the whole community too.
+              </p>
+            </div>
+          </div>
+          <div className="card bg-black/20 basis-80 shadow-xl">
+            <div className="card-body">
+              <h3 className="card-title">
+                <HeartIcon /> Extended Family
+              </h3>
+              <p>
+                If you haven&apos;t yet learned your family&apos;s ancestral
+                language, and now you feel a barrier between yourself and your
+                grandparents or your cousins, this is the &ldquo;linguistic
+                generation gap.&rdquo;
+              </p>
+              <p>
+                We are here to help – go ahead and dive into Sunlo, and ask your
+                parents or your fun cousin to join as a friend and help you
+                along the way.
+              </p>
+            </div>
+          </div>
+        </div>
+      </section>
+      <section className="text-center my-10 pb-16">
+        <h2 className="h2">Ready to get started?</h2>
+        <Link
+          tabIndex={1}
+          href="/login"
+          className="btn btn-lg w-80 btn-primary btn-outline bg-white focus:shadow focus:shadow-white"
+        >
+          Sign up and start learning &rarr;
+        </Link>
+      </section>
+
+      <section
+        data-theme="light"
+        className="card my-16 pt-4 @lg:pt-10 pb-16 px-4 @lg:px-8"
+      >
+        <h2 className="h2 text-center px-4 pb-6">The Story Behind Sunlo</h2>
+        <div className="columns-1 @lg:columns-2 space-y-4 text-xl/8">
+          <p>
+            Sunlo is a labour of love that started in 2015 when I came to India
+            and found tools like the owl app lacking. (You know the one...)
+          </p>
+          <p>
+            I found I didn&apos;t need to know the word for &ldquo;Tomato&rdquo;
+            as much as I needed to be able to point at the tomato and say
+            &ldquo;give me 6 of those (polite).&rdquo; When I learned to do
+            this, the rest started to fall into place.
+          </p>
+          <p>
+            As I tried other methods and researched the science of
+            language-learning I started to feel a lack of good tools for helping
+            people learn languages that are <em>different in structure</em> from
+            the ones they&apos;re raised on. Learning{' '}
+            <span className="underline decoration-accent decoration-[3px]">
+              Spanish
+            </span>{' '}
+            from{' '}
+            <span className="underline decoration-accent decoration-[3px]">
+              English
+            </span>{' '}
+            may be straight-forward with lessons on vocabulary and grammar, but
+            the same approach might not work to learn{' '}
+            <span className="underline decoration-accent decoration-[3px]">
+              Arabic
+            </span>
+            ,{' '}
+            <span className="underline decoration-accent decoration-[3px]">
+              Xhosa
+            </span>{' '}
+            or{' '}
+            <span className="underline decoration-accent decoration-[3px]">
+              Mandarin
+            </span>
+            , whose grammars and patterns may be too unfamiliar for me to
+            succeed with that formulaic approach.
+          </p>
+          <p>
+            The answer to this problem seems to be a phrase-based approach,
+            where you don&apos;t necessarily try to understand every meaning and
+            tense, you learn <em>chunks of meaning</em> that you can use in real
+            life. And when you do, it creates a reward in your brain and helps
+            you connect with others in your world, both of which aid in the
+            formation of lasting, usable memory.
+          </p>
+          <p>
+            There&apos;s a fantastic (and free) app called Anki – which I also
+            use and love! – which takes this phrase-based approach, and{' '}
+            <a
+              className="link decoration-base-content/50 hover:decoration-base-content"
+              href="https://docs.ankiweb.net/background.html"
+            >
+              their background doc
+            </a>{' '}
+            does a great job of explaining why it&apos;s so effective.{' '}
+          </p>
+          <p>
+            But the most important part of my learning journey was the friends I
+            made who were excited to help me. There are a couple of friends who
+            have an intuitive sense of how much I know and don&apos;t know, and
+            are able to speak to me in a way that they know I&apos;ll understand
+            enough of what they&apos;re saying that I can learn and figure out
+            the rest.
+          </p>
+          <p>
+            So Sunlo is a bit of a love song to those friends – the very reason
+            we learn in the first place – to make them main characters in the
+            play as well. It invites them to help curate your deck of flash
+            cards and find or create the ones they think you&apos;ll need and
+            use and love. If you&apos;re a friend helping a newcomer learn your
+            language – Sunlo is for you too. Thank you, and welcome! I hope you
+            love it.
+          </p>
+          <p className="italic text-center">– M</p>
+        </div>
+      </section>
+      <section className="my-16 pt-4 @lg:pt-10 pb-16">
+        <h2 className="h2 text-center px-4 pb-6">
+          Sunlo is Free and Open Source
+        </h2>
+        <div className="columns-1 @xl:columns-3 @lg:columns-2 space-y-4 text-xl/8">
+          <p>
+            Sunlo is a labour of love. If you&apos;re a developer or a language
+            expert and would like to help,{' '}
+            <a
+              className="link decoration-white/50 hover:decoration-white"
+              href="https://github.com/michaelsnook/sunlo-nextjs"
+            >
+              check out the code on GitHub
+            </a>{' '}
+            or find me on socials (
+            <a
+              className="link decoration-white/50 hover:decoration-white"
+              href="https://twitter.com/michaelsnook"
+            >
+              tw
+            </a>{' '}
+            &amp;{' '}
+            <a
+              className="link decoration-white/50 hover:decoration-white"
+              href="https://bsky.app/profile/michaelsnook.com"
+            >
+              bsky
+            </a>
+            ).
+          </p>
+          <p>
+            Maybe one day Sunlo will become a business, but for now it is just
+            me, trying to learn languages to connect with the people I love. It
+            is my humble wish that it may help others do the same 🙏
+          </p>
+          <p>
+            If you have feedback or suggestions or requests, please do get in
+            touch. Sunlo can&apos;t be everything to everyone, but it can always
+            get better! ❤️
+          </p>
+        </div>
+      </section>
     </>
   )
 }
+
+const PhraseIcon = () => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 24 24"
+    strokeWidth={1.5}
+    stroke="currentColor"
+    className="size-6"
+  >
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      d="M7.5 8.25h9m-9 3H12m-9.75 1.51c0 1.6 1.123 2.994 2.707 3.227 1.129.166 2.27.293 3.423.379.35.026.67.21.865.501L12 21l2.755-4.133a1.14 1.14 0 0 1 .865-.501 48.172 48.172 0 0 0 3.423-.379c1.584-.233 2.707-1.626 2.707-3.228V6.741c0-1.602-1.123-2.995-2.707-3.228A48.394 48.394 0 0 0 12 3c-2.392 0-4.744.175-7.043.513C3.373 3.746 2.25 5.14 2.25 6.741v6.018Z"
+    />
+  </svg>
+)
+
+const SocialIcon = () => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 24 24"
+    strokeWidth={1.5}
+    stroke="currentColor"
+    className="size-6"
+  >
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      d="M18 18.72a9.094 9.094 0 0 0 3.741-.479 3 3 0 0 0-4.682-2.72m.94 3.198.001.031c0 .225-.012.447-.037.666A11.944 11.944 0 0 1 12 21c-2.17 0-4.207-.576-5.963-1.584A6.062 6.062 0 0 1 6 18.719m12 0a5.971 5.971 0 0 0-.941-3.197m0 0A5.995 5.995 0 0 0 12 12.75a5.995 5.995 0 0 0-5.058 2.772m0 0a3 3 0 0 0-4.681 2.72 8.986 8.986 0 0 0 3.74.477m.94-3.197a5.971 5.971 0 0 0-.94 3.197M15 6.75a3 3 0 1 1-6 0 3 3 0 0 1 6 0Zm6 3a2.25 2.25 0 1 1-4.5 0 2.25 2.25 0 0 1 4.5 0Zm-13.5 0a2.25 2.25 0 1 1-4.5 0 2.25 2.25 0 0 1 4.5 0Z"
+    />
+  </svg>
+)
+
+const CuriosityIcon = () => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 24 24"
+    strokeWidth={1.5}
+    stroke="currentColor"
+    className="size-6"
+  >
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      d="M9.813 15.904 9 18.75l-.813-2.846a4.5 4.5 0 0 0-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 0 0 3.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 0 0 3.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 0 0-3.09 3.09ZM18.259 8.715 18 9.75l-.259-1.035a3.375 3.375 0 0 0-2.455-2.456L14.25 6l1.036-.259a3.375 3.375 0 0 0 2.455-2.456L18 2.25l.259 1.035a3.375 3.375 0 0 0 2.456 2.456L21.75 6l-1.035.259a3.375 3.375 0 0 0-2.456 2.456ZM16.894 20.567 16.5 21.75l-.394-1.183a2.25 2.25 0 0 0-1.423-1.423L13.5 18.75l1.183-.394a2.25 2.25 0 0 0 1.423-1.423l.394-1.183.394 1.183a2.25 2.25 0 0 0 1.423 1.423l1.183.394-1.183.394a2.25 2.25 0 0 0-1.423 1.423Z"
+    />
+  </svg>
+)
+
+const PlaneIcon = () => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 24 24"
+    strokeWidth={1.5}
+    stroke="currentColor"
+    className="size-6"
+  >
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      d="M6 12 3.269 3.125A59.769 59.769 0 0 1 21.485 12 59.768 59.768 0 0 1 3.27 20.875L5.999 12Zm0 0h7.5"
+    />
+  </svg>
+)
+
+const HeartIcon = () => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 24 24"
+    strokeWidth={1.5}
+    stroke="currentColor"
+    className="size-6"
+  >
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      d="M21 8.25c0-2.485-2.099-4.5-4.688-4.5-1.935 0-3.597 1.126-4.312 2.733-.715-1.607-2.377-2.733-4.313-2.733C5.1 3.75 3 5.765 3 8.25c0 7.22 9 12 9 12s9-4.78 9-12Z"
+    />
+  </svg>
+)
+
+const FriendIcon = () => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 24 24"
+    strokeWidth={1.5}
+    stroke="currentColor"
+    className="size-6"
+  >
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      d="M18 7.5v3m0 0v3m0-3h3m-3 0h-3m-2.25-4.125a3.375 3.375 0 1 1-6.75 0 3.375 3.375 0 0 1 6.75 0ZM3 19.235v-.11a6.375 6.375 0 0 1 12.75 0v.109A12.318 12.318 0 0 1 9.374 21c-2.331 0-4.512-.645-6.374-1.766Z"
+    />
+  </svg>
+)

--- a/app/page.jsx
+++ b/app/page.jsx
@@ -254,7 +254,17 @@ export default function Page() {
         </h2>
         <div className="columns-1 @xl:columns-3 @lg:columns-2 space-y-4 text-xl/8">
           <p>
-            Sunlo is a labour of love. If you&apos;re a developer or a language
+            For now Sunlo is just
+            me, trying to learn languages to connect with the people I love. It
+            is my humble wish that it may help others do the same 🙏
+          </p>
+          <p>
+            If you have feedback or suggestions or requests, please do get in
+            touch. Sunlo can&apos;t be everything to everyone, but it can always
+            get better! ❤️
+          </p>
+          <p>
+            If you&apos;re a developer or a language
             expert and would like to help,{' '}
             <a
               className="link decoration-white/50 hover:decoration-white"
@@ -277,16 +287,6 @@ export default function Page() {
               bsky
             </a>
             ).
-          </p>
-          <p>
-            Maybe one day Sunlo will become a business, but for now it is just
-            me, trying to learn languages to connect with the people I love. It
-            is my humble wish that it may help others do the same 🙏
-          </p>
-          <p>
-            If you have feedback or suggestions or requests, please do get in
-            touch. Sunlo can&apos;t be everything to everyone, but it can always
-            get better! ❤️
           </p>
         </div>
       </section>

--- a/app/page.jsx
+++ b/app/page.jsx
@@ -5,7 +5,7 @@ export default function Page() {
   return (
     <>
       <main className="flex flex-row flex-wrap gap-4 mb-8 @xl:my-20">
-        <article className="space-y-4 flex flex-col basis-11/12 @xl:basis-3/5 justify-center mx-auto max-w-[537px]">
+        <div className="space-y-4 flex flex-col basis-11/12 @xl:basis-3/5 justify-center mx-auto max-w-[537px]">
           <h1 className="text-4xl text-center @xl:text-start @xl:h-24 @xl:mt-16">
             Sunlo is a social
             <br />
@@ -15,16 +15,17 @@ export default function Page() {
             Create your own flash cards, pick from a crowd-sourced pool, or send
             your friend some key phrases to help them learn.
           </p>
-        </article>
-        <aside className="space-y-4 @xl:basis-1/3 flex-none text-center mx-auto">
+        </div>
+        <div className="space-y-4 @xl:basis-1/3 flex-none text-center mx-auto">
           <GarlicBroccoli className="mx-auto" />
           <Link
+            tabIndex={1}
             href="/login"
-            className="btn btn-lg btn-primary btn-outline bg-white"
+            className="btn btn-lg btn-primary btn-outline bg-white focus:shadow focus:shadow-white"
           >
             Log in or sign up &rarr;
           </Link>
-        </aside>
+        </div>
       </main>
 
       <div className="w-app bg-black/30 text-warning alert">

--- a/app/page.jsx
+++ b/app/page.jsx
@@ -27,10 +27,10 @@ export default function Page() {
         </aside>
       </main>
 
-      <div className="w-app bg-black/60 text-warning">
-        <p className="p-4 text-center">
-          ⚠️ Sunlo is under development; it is very incomplete but most of
-          what&apos;s there should work so if you do spot a problem, please let
+      <div className="w-app bg-black/30 text-warning alert">
+        <p className="text-center">
+          ⚠️ Sunlo is under development; it is incomplete but most of
+          what&apos;s there should work, so if you do spot a problem, please let
           me know! ⚠️
         </p>
       </div>

--- a/app/page.jsx
+++ b/app/page.jsx
@@ -290,6 +290,20 @@ export default function Page() {
           </p>
         </div>
       </section>
+      <footer className="my-16 pt-4 @lg:pt-10 pb-16 flex flex-row flex-wrap justify-center gap-8">
+        <a
+          className="btn btn-ghost"
+          href="https://github.com/michaelsnook/sunlo-nextjs"
+        >
+          <CodeIcon /> &nbsp;GitHub
+        </a>
+        <Link className="btn btn-ghost" href="/login">
+          <LoginIcon /> &nbsp;Login
+        </Link>
+        <Link className="btn btn-ghost" href="/signup">
+          <SignupIcon /> &nbsp;Signup
+        </Link>
+      </footer>
     </>
   )
 }
@@ -392,6 +406,74 @@ const FriendIcon = () => (
       strokeLinecap="round"
       strokeLinejoin="round"
       d="M18 7.5v3m0 0v3m0-3h3m-3 0h-3m-2.25-4.125a3.375 3.375 0 1 1-6.75 0 3.375 3.375 0 0 1 6.75 0ZM3 19.235v-.11a6.375 6.375 0 0 1 12.75 0v.109A12.318 12.318 0 0 1 9.374 21c-2.331 0-4.512-.645-6.374-1.766Z"
+    />
+  </svg>
+)
+
+const CodeIcon = () => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 24 24"
+    strokeWidth={1.5}
+    stroke="currentColor"
+    className="size-6"
+  >
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      d="M17.25 6.75 22.5 12l-5.25 5.25m-10.5 0L1.5 12l5.25-5.25m7.5-3-4.5 16.5"
+    />
+  </svg>
+)
+
+const PencilIcon = () => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 24 24"
+    strokeWidth={1.5}
+    stroke="currentColor"
+    className="size-6"
+  >
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      d="m16.862 4.487 1.687-1.688a1.875 1.875 0 1 1 2.652 2.652L6.832 19.82a4.5 4.5 0 0 1-1.897 1.13l-2.685.8.8-2.685a4.5 4.5 0 0 1 1.13-1.897L16.863 4.487Zm0 0L19.5 7.125"
+    />
+  </svg>
+)
+
+const LoginIcon = () => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 24 24"
+    strokeWidth={1.5}
+    stroke="currentColor"
+    className="size-6"
+  >
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      d="M8.25 9V5.25A2.25 2.25 0 0 1 10.5 3h6a2.25 2.25 0 0 1 2.25 2.25v13.5A2.25 2.25 0 0 1 16.5 21h-6a2.25 2.25 0 0 1-2.25-2.25V15M12 9l3 3m0 0-3 3m3-3H2.25"
+    />
+  </svg>
+)
+
+const SignupIcon = () => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 24 24"
+    strokeWidth={1.5}
+    stroke="currentColor"
+    className="size-6"
+  >
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      d="M15 9h3.75M15 12h3.75M15 15h3.75M4.5 19.5h15a2.25 2.25 0 0 0 2.25-2.25V6.75A2.25 2.25 0 0 0 19.5 4.5h-15a2.25 2.25 0 0 0-2.25 2.25v10.5A2.25 2.25 0 0 0 4.5 19.5Zm6-10.125a1.875 1.875 0 1 1-3.75 0 1.875 1.875 0 0 1 3.75 0Zm1.294 6.336a6.721 6.721 0 0 1-3.17.789 6.721 6.721 0 0 1-3.168-.789 3.376 3.376 0 0 1 6.338 0Z"
     />
   </svg>
 )

--- a/app/privacy-policy/page.jsx
+++ b/app/privacy-policy/page.jsx
@@ -1,0 +1,501 @@
+export default function Page() {
+  return (
+    <div data-theme="light" className="card p-10">
+      <div className="prose">
+        <h1>Privacy Policy</h1>
+        <em>Last updated: June 24, 2024</em>
+        <div className="text-xl card bg-info/20 border border-info flex flex-col px-8 my-4">
+          <p>
+            <strong>tl;dr:</strong> In order to create an account you need to
+            enter an email address, and logging in leaves a cookie on your
+            device. But other than this we are not collecting or tracking any
+            other personal information; we aren&apos;t selling or providing your
+            data to anyone else, and we reserve zero rights to do so in the
+            future.
+          </p>
+          <p className="mt-0">
+            Your <em>user name and avatar</em> are public to help you find your
+            friends, but you don&apos;t have to use your real name or pic, of
+            course. The cards you create are also public, because we are
+            crowd-sourcing these flash cards for the benefit of all, so
+            don&apos;t put private data in them please.
+          </p>
+          <p className="mt-0">
+            We have not yet implemented GDPR-compliance features like the
+            &ldquo;forget me&rdquo; feature, so if you are in the European Union
+            please do not use our service.
+          </p>
+        </div>
+        <p>
+          This Privacy Policy describes Our policies and procedures on the
+          collection, use and disclosure of Your information when You use the
+          Service and tells You about Your privacy rights and how the law
+          protects You.
+        </p>
+        <p>
+          We use Your Personal data to provide and improve the Service. By using
+          the Service, You agree to the collection and use of information in
+          accordance with this Privacy Policy. This Privacy Policy has been
+          created with the help of the{' '}
+          <a
+            href="https://www.freeprivacypolicy.com/free-privacy-policy-generator/"
+            target="_blank"
+          >
+            Free Privacy Policy Generator
+          </a>
+          .
+        </p>
+        <h2>Interpretation and Definitions</h2>
+        <h3>Interpretation</h3>
+        <p>
+          The words of which the initial letter is capitalized have meanings
+          defined under the following conditions. The following definitions
+          shall have the same meaning regardless of whether they appear in
+          singular or in plural.
+        </p>
+        <h3>Definitions</h3>
+        <p>For the purposes of this Privacy Policy:</p>
+        <ul>
+          <li>
+            <p>
+              <strong>Account</strong> means a unique account created for You to
+              access our Service or parts of our Service.
+            </p>
+          </li>
+          <li>
+            <p>
+              <strong>Affiliate</strong> means an entity that controls, is
+              controlled by or is under common control with a party, where
+              &quot;control&quot; means ownership of 50% or more of the shares,
+              equity interest or other securities entitled to vote for election
+              of directors or other managing authority.
+            </p>
+          </li>
+          <li>
+            <p>
+              <strong>Application</strong> refers to Sunlo, the software program
+              provided by the Entity.
+            </p>
+          </li>
+          <li>
+            <p>
+              <strong>Entity</strong> (referred to as either &quot;the
+              Entity&quot;, &quot;We&quot;, &quot;Us&quot; or &quot;Our&quot; in
+              this Agreement) refers to Sunlo.
+            </p>
+          </li>
+          <li>
+            <p>
+              <strong>Cookies</strong> are small files that are placed on Your
+              computer, mobile device or any other device by a website,
+              containing the details of Your browsing history on that website
+              among its many uses.
+            </p>
+          </li>
+          <li>
+            <p>
+              <strong>Country</strong> refers to: Karnataka, India
+            </p>
+          </li>
+          <li>
+            <p>
+              <strong>Device</strong> means any device that can access the
+              Service such as a computer, a cellphone or a digital tablet.
+            </p>
+          </li>
+          <li>
+            <p>
+              <strong>Personal Data</strong> is any information that relates to
+              an identified or identifiable individual.
+            </p>
+          </li>
+          <li>
+            <p>
+              <strong>Service</strong> refers to the Application or the Website
+              or both.
+            </p>
+          </li>
+          <li>
+            <p>
+              <strong>Service Provider</strong> means any natural or legal
+              person who processes the data on behalf of the Entity. It refers
+              to third-party companies or individuals employed by the Entity to
+              facilitate the Service, to provide the Service on behalf of the
+              Entity, to perform services related to the Service or to assist
+              the Entity in analyzing how the Service is used.
+            </p>
+          </li>
+          <li>
+            <p>
+              <strong>Usage Data</strong> refers to data collected
+              automatically, either generated by the use of the Service or from
+              the Service infrastructure itself (for example, the duration of a
+              page visit).
+            </p>
+          </li>
+          <li>
+            <p>
+              <strong>Website</strong> refers to Sunlo, accessible from{' '}
+              <a
+                href="https://sunlo.app"
+                rel="external nofollow noopener"
+                target="_blank"
+              >
+                https://sunlo.app
+              </a>
+            </p>
+          </li>
+          <li>
+            <p>
+              <strong>You</strong> means the individual accessing or using the
+              Service, or the Entity, or other legal entity on behalf of which
+              such individual is accessing or using the Service, as applicable.
+            </p>
+          </li>
+        </ul>
+        <h2>Collecting and Using Your Personal Data</h2>
+        <h3>Types of Data Collected</h3>
+        <h4>Personal Data</h4>
+        <p>
+          While using Our Service, We may ask You to provide Us with certain
+          personally identifiable information that can be used to contact or
+          identify You. Personally identifiable information may include, but is
+          not limited to:
+        </p>
+        <ul>
+          <li>
+            <p>Email address</p>
+          </li>
+          <li>
+            <p>User name</p>
+          </li>
+          <li>
+            <p>Avatar (profile picture)</p>
+          </li>
+          <li>
+            <p>Usage Data</p>
+          </li>
+        </ul>
+        <h4>Usage Data</h4>
+        <p>Usage Data is collected automatically when using the Service.</p>
+        <p>
+          Usage Data may include information such as Your Device&apos;s Internet
+          Protocol address (e.g. IP address), browser type, browser version, the
+          pages of our Service that You visit, the time and date of Your visit,
+          the time spent on those pages, unique device identifiers and other
+          diagnostic data.
+        </p>
+        <p>
+          When You access the Service by or through a mobile device, We may
+          collect certain information automatically, including, but not limited
+          to, the type of mobile device You use, Your mobile device unique ID,
+          the IP address of Your mobile device, Your mobile operating system,
+          the type of mobile Internet browser You use, unique device identifiers
+          and other diagnostic data.
+        </p>
+        <p>
+          We may also collect information that Your browser sends whenever You
+          visit our Service or when You access the Service by or through a
+          mobile device.
+        </p>
+        <h4>Tracking Technologies and Cookies</h4>
+        <p>
+          We use Cookies and similar tracking technologies to track the activity
+          on Our Service and store certain information. Tracking technologies
+          used are beacons, tags, and scripts to collect and track information
+          and to improve and analyze Our Service. The technologies We use may
+          include:
+        </p>
+        <ul>
+          <li>
+            <strong>Cookies or Browser Cookies.</strong> A cookie is a small
+            file placed on Your Device. You can instruct Your browser to refuse
+            all Cookies or to indicate when a Cookie is being sent. However, if
+            You do not accept Cookies, You may not be able to use some parts of
+            our Service. Unless you have adjusted Your browser setting so that
+            it will refuse Cookies, our Service may use Cookies.
+          </li>
+          <li>
+            <strong>Web Beacons.</strong> Certain sections of our Service and
+            our emails may contain small electronic files known as web beacons
+            (also referred to as clear gifs, pixel tags, and single-pixel gifs)
+            that permit the Entity, for example, to count users who have visited
+            those pages or opened an email and for other related website
+            statistics (for example, recording the popularity of a certain
+            section and verifying system and server integrity).
+          </li>
+        </ul>
+        <p>
+          Cookies can be &quot;Persistent&quot; or &quot;Session&quot; Cookies.
+          Persistent Cookies remain on Your personal computer or mobile device
+          when You go offline, while Session Cookies are deleted as soon as You
+          close Your web browser. Learn more about cookies on the{' '}
+          <a
+            href="https://www.freeprivacypolicy.com/blog/sample-privacy-policy-template/#Use_Of_Cookies_And_Tracking"
+            target="_blank"
+          >
+            Free Privacy Policy website
+          </a>{' '}
+          article.
+        </p>
+        <p>
+          We use both Session and Persistent Cookies for the purposes set out
+          below:
+        </p>
+        <ul>
+          <li>
+            <p>
+              <strong>Necessary / Essential Cookies</strong>
+            </p>
+            <p>Type: Session Cookies</p>
+            <p>Administered by: Us</p>
+            <p>
+              Purpose: These Cookies are essential to provide You with services
+              available through the Website and to enable You to use some of its
+              features. They help to authenticate users and prevent fraudulent
+              use of user accounts. Without these Cookies, the services that You
+              have asked for cannot be provided, and We only use these Cookies
+              to provide You with those services.
+            </p>
+          </li>
+          <li>
+            <p>
+              <strong>Cookies Policy / Notice Acceptance Cookies</strong>
+            </p>
+            <p>Type: Persistent Cookies</p>
+            <p>Administered by: Us</p>
+            <p>
+              Purpose: These Cookies identify if users have accepted the use of
+              cookies on the Website.
+            </p>
+          </li>
+          <li>
+            <p>
+              <strong>Functionality Cookies</strong>
+            </p>
+            <p>Type: Persistent Cookies</p>
+            <p>Administered by: Us</p>
+            <p>
+              Purpose: These Cookies allow us to remember choices You make when
+              You use the Website, such as remembering your login details or
+              language preference. The purpose of these Cookies is to provide
+              You with a more personal experience and to avoid You having to
+              re-enter your preferences every time You use the Website.
+            </p>
+          </li>
+        </ul>
+        <p>
+          For more information about the cookies we use and your choices
+          regarding cookies, please visit our Cookies Policy or the Cookies
+          section of our Privacy Policy.
+        </p>
+        <h3>Use of Your Personal Data</h3>
+        <p>The Entity may use Personal Data for the following purposes:</p>
+        <ul>
+          <li>
+            <p>
+              <strong>To provide and maintain our Service</strong>, including to
+              monitor the usage of our Service.
+            </p>
+          </li>
+          <li>
+            <p>
+              <strong>To manage Your Account:</strong> to manage Your
+              registration as a user of the Service. The Personal Data You
+              provide can give You access to different functionalities of the
+              Service that are available to You as a registered user.
+            </p>
+          </li>
+          <li>
+            <p>
+              <strong>To contact You:</strong> To contact You by email, or other
+              equivalent forms of electronic communication, such as a mobile
+              application&apos;s push notifications regarding updates or
+              informative communications related to the functionalities,
+              products or contracted services, including the security updates,
+              when necessary or reasonable for their implementation.
+            </p>
+          </li>
+          <li>
+            <p>
+              <strong>To provide You</strong> with news, special offers and
+              general information about other goods, services and events which
+              we offer that are similar to those that you have already purchased
+              or enquired about unless You have opted not to receive such
+              information.
+            </p>
+          </li>
+          <li>
+            <p>
+              <strong>To manage Your requests:</strong> To attend and manage
+              Your requests to Us.
+            </p>
+          </li>
+          <li>
+            <p>
+              <strong>For other purposes</strong>: We may use Your information
+              for other purposes, such as data analysis, identifying usage
+              trends, determining the effectiveness of our promotional campaigns
+              and to evaluate and improve our Service, products, services,
+              marketing and your experience.
+            </p>
+          </li>
+        </ul>
+        <p>
+          We may share Your personal information in the following situations:
+        </p>
+        <ul>
+          <li>
+            <strong>With other users:</strong> when You share personal
+            information or otherwise interact in the public areas with other
+            users, such information may be viewed by all users and may be
+            publicly distributed outside.
+          </li>
+          <li>
+            <strong>With Your consent</strong>: We may disclose Your personal
+            information for any other purpose with Your consent.
+          </li>
+        </ul>
+        <h3>Retention of Your Personal Data</h3>
+        <p>
+          The Entity will retain Your Personal Data only for as long as is
+          necessary for the purposes set out in this Privacy Policy. We will
+          retain and use Your Personal Data to the extent necessary to comply
+          with our legal obligations (for example, if we are required to retain
+          your data to comply with applicable laws), resolve disputes, and
+          enforce our legal agreements and policies.
+        </p>
+        <p>
+          The Entity will also retain Usage Data for internal analysis purposes.
+          Usage Data is generally retained for a shorter period of time, except
+          when this data is used to strengthen the security or to improve the
+          functionality of Our Service, or We are legally obligated to retain
+          this data for longer time periods.
+        </p>
+        <h3>Transfer of Your Personal Data</h3>
+        <p>
+          Your information, including Personal Data, is processed at the
+          Entity&apos;s operating offices and in any other places where the
+          parties involved in the processing are located. It means that this
+          information may be transferred to — and maintained on — computers
+          located outside of Your state, province, country or other governmental
+          jurisdiction where the data protection laws may differ than those from
+          Your jurisdiction.
+        </p>
+        <p>
+          Your consent to this Privacy Policy followed by Your submission of
+          such information represents Your agreement to that transfer.
+        </p>
+        <p>
+          The Entity will take all steps reasonably necessary to ensure that
+          Your data is treated securely and in accordance with this Privacy
+          Policy and no transfer of Your Personal Data will take place to an
+          organization or a country unless there are adequate controls in place
+          including the security of Your data and other personal information.
+        </p>
+        <h3>Delete Your Personal Data</h3>
+        <p>
+          You have the right to delete or request that We assist in deleting the
+          Personal Data that We have collected about You.
+        </p>
+        <p>
+          Our Service may give You the ability to delete certain information
+          about You from within the Service.
+        </p>
+        <p>
+          You may update, amend, or delete Your information at any time by
+          signing in to Your Account, if you have one, and visiting the account
+          settings section that allows you to manage Your personal information.
+          You may also contact Us to request access to, correct, or delete any
+          personal information that You have provided to Us.
+        </p>
+        <p>
+          Please note, however, that We may need to retain certain information
+          when we have a legal obligation or lawful basis to do so.
+        </p>
+        <h3>Disclosure of Your Personal Data</h3>
+        <h4>Law enforcement</h4>
+        <p>
+          Under certain circumstances, the Entity may be required to disclose
+          Your Personal Data if required to do so by law or in response to valid
+          requests by public authorities (e.g. a court or a government agency).
+        </p>
+        <h4>Other legal requirements</h4>
+        <p>
+          The Entity may disclose Your Personal Data in the good faith belief
+          that such action is necessary to:
+        </p>
+        <ul>
+          <li>Comply with a legal obligation</li>
+          <li>Protect and defend the rights or property of the Entity</li>
+          <li>
+            Prevent or investigate possible wrongdoing in connection with the
+            Service
+          </li>
+          <li>
+            Protect the personal safety of Users of the Service or the public
+          </li>
+          <li>Protect against legal liability</li>
+        </ul>
+        <h3>Security of Your Personal Data</h3>
+        <p>
+          The security of Your Personal Data is important to Us, but remember
+          that no method of transmission over the Internet, or method of
+          electronic storage is 100% secure. While We strive to use commercially
+          acceptable means to protect Your Personal Data, We cannot guarantee
+          its absolute security.
+        </p>
+        <h2>Children&apos;s Privacy</h2>
+        <p>
+          Our Service does not address anyone under the age of 13. We do not
+          knowingly collect personally identifiable information from anyone
+          under the age of 13. If You are a parent or guardian and You are aware
+          that Your child has provided Us with Personal Data, please contact Us.
+          If We become aware that We have collected Personal Data from anyone
+          under the age of 13 without verification of parental consent, We take
+          steps to remove that information from Our servers.
+        </p>
+        <p>
+          If We need to rely on consent as a legal basis for processing Your
+          information and Your country requires consent from a parent, We may
+          require Your parent&apos;s consent before We collect and use that
+          information.
+        </p>
+        <h2>Links to Other Websites</h2>
+        <p>
+          Our Service may contain links to other websites that are not operated
+          by Us. If You click on a third party link, You will be directed to
+          that third party&apos;s site. We strongly advise You to review the
+          Privacy Policy of every site You visit.
+        </p>
+        <p>
+          We have no control over and assume no responsibility for the content,
+          privacy policies or practices of any third party sites or services.
+        </p>
+        <h2>Changes to this Privacy Policy</h2>
+        <p>
+          We may update Our Privacy Policy from time to time. We will notify You
+          of any changes by posting the new Privacy Policy on this page.
+        </p>
+        <p>
+          We will let You know via email and/or a prominent notice on Our
+          Service, prior to the change becoming effective and update the
+          &quot;Last updated&quot; date at the top of this Privacy Policy.
+        </p>
+        <p>
+          You are advised to review this Privacy Policy periodically for any
+          changes. Changes to this Privacy Policy are effective when they are
+          posted on this page.
+        </p>
+        <h2>Contact Us</h2>
+        <p>
+          If you have any questions about this Privacy Policy, You can contact
+          us:
+        </p>
+        <ul>
+          <li>By email: sunlo dot app at gmail dot com</li>
+        </ul>
+      </div>
+    </div>
+  )
+}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -62,6 +62,9 @@
   .h2 {
     @apply lg:text-4xl md:text-3xl text-2xl my-4; /* font-display;*/
   }
+  .d2 {
+    @apply lg:text-6xl md:text-5xl sm:text-4xl text-3xl; /* font-display;*/
+  }
   .h3 {
     @apply md:text-2xl text-xl mt-1 mb-3; /* font-display;*/
   }


### PR DESCRIPTION
This PR adds a bunch of content and some storytelling to the front page, and a very basic/restrictive privacy policy.

It is a little bit strange to add the privacy policy now because  it gives an air of completion and professionalism but it is just ripped from a free privacy policy generator and then modified a bit to ensure it's not talking about a Company and that it has a TL;DR that makes a few things super clear: namely what data we are collecting, that your user name and avatar are public, that we're not doing any other/hidden cookie-ing or tracking, that we're not sharing or selling any data with anyone.

I thought it was better to do this now than wait _without any_ privacy policy for an indefinite amount of time and then maybe have actual users to worry about back-filling privacy consent for, and so on. I will also have to add it to the login screen and the sidebar but I think it's okay to do that in another PR. This one is about the home page, and in this sense the existence of the policy page makes that home page update complete and also goes a long way to fulfilling some basic
obligations, despite not having gone through the entire site and finished making the privacy policy discoverable at every place we'd want. Soon.