### PR TITLE
Refactor data fetching

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,9 +1,16 @@
 {
-  "extends": "next/core-web-vitals",
-  "plugins": ["react-hooks"],
+  "extends": [
+    "next/core-web-vitals",
+    "plugin:@tanstack/eslint-plugin-query/recommended"
+  ],
+  "plugins": ["react-hooks", "@tanstack/query"],
   "rules": {
     "react-hooks/rules-of-hooks": "error",
-    "react-hooks/exhaustive-deps": "warn"
+    "react-hooks/exhaustive-deps": "warn",
+    "@tanstack/query/exhaustive-deps": "error",
+    // "@tanstack/query/no-deprecated-options": "warn",
+    // "@tanstack/query/prefer-query-object-syntax": "error",
+    "@tanstack/query/stable-query-client": "error"
   },
   "ignorePatterns": ["out/**/*"]
 }

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@tailwindcss/forms": "^0.5.3",
     "@tailwindcss/line-clamp": "^0.4.2",
     "@tailwindcss/typography": "^0.5.8",
+    "@tanstack/eslint-plugin-query": "^5.51.12",
     "@tanstack/react-query-devtools": "^4.24.12",
     "@tauri-apps/cli": "^2.0.0-beta.20",
     "@types/node": "^20.12.12",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,6 +51,9 @@ importers:
       '@tailwindcss/typography':
         specifier: ^0.5.8
         version: 0.5.13(tailwindcss@3.4.4)
+      '@tanstack/eslint-plugin-query':
+        specifier: ^5.51.12
+        version: 5.51.12(eslint@8.57.0)(typescript@5.4.5)
       '@tanstack/react-query-devtools':
         specifier: ^4.24.12
         version: 4.36.1(@tanstack/react-query@4.36.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -397,6 +400,11 @@ packages:
     peerDependencies:
       tailwindcss: '>=3.0.0 || insiders'
 
+  '@tanstack/eslint-plugin-query@5.51.12':
+    resolution: {integrity: sha512-vzUXXIVzDP2c6wVSJ+1imPGaKQ2ILuWnta64FJc/JnQ5WunfO17bQJSk6uKDbzTQG/YKgPYBMG3C9qFA4b7Ayg==}
+    peerDependencies:
+      eslint: ^8 || ^9
+
   '@tanstack/match-sorter-utils@8.15.1':
     resolution: {integrity: sha512-PnVV3d2poenUM31ZbZi/yXkBu3J7kd5k2u51CGwwNojag451AjTH9N6n41yjXz2fpLeewleyLBmNS6+HcGDlXw==}
     engines: {node: '>=12'}
@@ -526,9 +534,17 @@ packages:
     resolution: {integrity: sha512-Qh976RbQM/fYtjx9hs4XkayYujB/aPwglw2choHmf3zBjB4qOywWSdt9+KLRdHubGcoSwBnXUH2sR3hkyaERRg==}
     engines: {node: ^16.0.0 || >=18.0.0}
 
+  '@typescript-eslint/scope-manager@8.0.0-alpha.30':
+    resolution: {integrity: sha512-FGW/iPWGyPFamAVZ60oCAthMqQrqafUGebF8UKuq/ha+e9SVG6YhJoRzurlQXOVf8dHfOhJ0ADMXyFnMc53clg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
   '@typescript-eslint/types@7.2.0':
     resolution: {integrity: sha512-XFtUHPI/abFhm4cbCDc5Ykc8npOKBSJePY3a3s+lwumt7XWJuzP5cZcfZ610MIPHjQjNsOLlYK8ASPaNG8UiyA==}
     engines: {node: ^16.0.0 || >=18.0.0}
+
+  '@typescript-eslint/types@8.0.0-alpha.30':
+    resolution: {integrity: sha512-4WzLlw27SO9pK9UFj/Hu7WGo8WveT0SEiIpFVsV2WwtQmLps6kouwtVCB8GJPZKJyurhZhcqCoQVQFmpv441Vg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@typescript-eslint/typescript-estree@7.2.0':
     resolution: {integrity: sha512-cyxS5WQQCoBwSakpMrvMXuMDEbhOo9bNHHrNcEWis6XHx6KF518tkF1wBvKIn/tpq5ZpUYK7Bdklu8qY0MsFIA==}
@@ -539,9 +555,28 @@ packages:
       typescript:
         optional: true
 
+  '@typescript-eslint/typescript-estree@8.0.0-alpha.30':
+    resolution: {integrity: sha512-WSXbc9ZcXI+7yC+6q95u77i8FXz6HOLsw3ST+vMUlFy1lFbXyFL/3e6HDKQCm2Clt0krnoCPiTGvIn+GkYPn4Q==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@typescript-eslint/utils@8.0.0-alpha.30':
+    resolution: {integrity: sha512-rfhqfLqFyXhHNDwMnHiVGxl/Z2q/3guQ1jLlGQ0hi9Rb7inmwz42crM+NnLPR+2vEnwyw1P/g7fnQgQ3qvFx4g==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0
+
   '@typescript-eslint/visitor-keys@7.2.0':
     resolution: {integrity: sha512-c6EIQRHhcpl6+tO8EMR+kjkkV+ugUNXOmeASA1rlzkd8EPIriavpWoiEz1HR/VLhbVIdhqnV6E7JZm00cBDx2A==}
     engines: {node: ^16.0.0 || >=18.0.0}
+
+  '@typescript-eslint/visitor-keys@8.0.0-alpha.30':
+    resolution: {integrity: sha512-XZuNurZxBqmr6ZIRIwWFq7j5RZd6ZlkId/HZEWyfciK+CWoyOxSF9Pv2VXH9Rlu2ZG2PfbhLz2Veszl4Pfn7yA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@ungap/structured-clone@1.2.0':
     resolution: {integrity: sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==}
@@ -2542,6 +2577,14 @@ snapshots:
       postcss-selector-parser: 6.0.10
       tailwindcss: 3.4.4
 
+  '@tanstack/eslint-plugin-query@5.51.12(eslint@8.57.0)(typescript@5.4.5)':
+    dependencies:
+      '@typescript-eslint/utils': 8.0.0-alpha.30(eslint@8.57.0)(typescript@5.4.5)
+      eslint: 8.57.0
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+
   '@tanstack/match-sorter-utils@8.15.1':
     dependencies:
       remove-accents: 0.5.0
@@ -2651,7 +2694,14 @@ snapshots:
       '@typescript-eslint/types': 7.2.0
       '@typescript-eslint/visitor-keys': 7.2.0
 
+  '@typescript-eslint/scope-manager@8.0.0-alpha.30':
+    dependencies:
+      '@typescript-eslint/types': 8.0.0-alpha.30
+      '@typescript-eslint/visitor-keys': 8.0.0-alpha.30
+
   '@typescript-eslint/types@7.2.0': {}
+
+  '@typescript-eslint/types@8.0.0-alpha.30': {}
 
   '@typescript-eslint/typescript-estree@7.2.0(typescript@5.4.5)':
     dependencies:
@@ -2668,9 +2718,40 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/typescript-estree@8.0.0-alpha.30(typescript@5.4.5)':
+    dependencies:
+      '@typescript-eslint/types': 8.0.0-alpha.30
+      '@typescript-eslint/visitor-keys': 8.0.0-alpha.30
+      debug: 4.3.5
+      globby: 11.1.0
+      is-glob: 4.0.3
+      minimatch: 9.0.4
+      semver: 7.6.2
+      ts-api-utils: 1.3.0(typescript@5.4.5)
+    optionalDependencies:
+      typescript: 5.4.5
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/utils@8.0.0-alpha.30(eslint@8.57.0)(typescript@5.4.5)':
+    dependencies:
+      '@eslint-community/eslint-utils': 4.4.0(eslint@8.57.0)
+      '@typescript-eslint/scope-manager': 8.0.0-alpha.30
+      '@typescript-eslint/types': 8.0.0-alpha.30
+      '@typescript-eslint/typescript-estree': 8.0.0-alpha.30(typescript@5.4.5)
+      eslint: 8.57.0
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+
   '@typescript-eslint/visitor-keys@7.2.0':
     dependencies:
       '@typescript-eslint/types': 7.2.0
+      eslint-visitor-keys: 3.4.3
+
+  '@typescript-eslint/visitor-keys@8.0.0-alpha.30':
+    dependencies:
+      '@typescript-eslint/types': 8.0.0-alpha.30
       eslint-visitor-keys: 3.4.3
 
   '@ungap/structured-clone@1.2.0': {}

--- a/src/app/(app)/deck/[lang]/client.tsx
+++ b/src/app/(app)/deck/[lang]/client.tsx
@@ -1,0 +1,8 @@
+'use client'
+
+import { loadLanguage, useLanguage } from './loader'
+
+export default function ClientPage({ lang }) {
+  const { data, error, status } = useLanguage(lang)
+  return <>{JSON.stringify(data, null, 2)}</>
+}

--- a/src/app/(app)/deck/[lang]/layout.tsx
+++ b/src/app/(app)/deck/[lang]/layout.tsx
@@ -1,0 +1,10 @@
+import Loader from './loader'
+
+export default function Layout({ params: { lang }, children }) {
+  return (
+    <>
+      <Loader lang={lang} />
+      {children}
+    </>
+  )
+}

--- a/src/app/(app)/deck/[lang]/loader.tsx
+++ b/src/app/(app)/deck/[lang]/loader.tsx
@@ -1,0 +1,33 @@
+'use client'
+
+import { useQuery, useQueryClient } from '@tanstack/react-query'
+import supabase from 'lib/supabase-client'
+
+export async function loadLanguage({ queryKey }: { queryKey: Array<string> }) {
+  console.log(`fetching the language:`, queryKey[1])
+  const { data, error } = await supabase
+    .from('language')
+    .select('*, phrase(*, phrase_translation(*))')
+    .eq('lang', queryKey[1])
+  if (error) throw error
+  return data
+}
+
+export function useLanguage(lang: string) {
+  console.log(`running useLanguage:`, lang)
+  // @ts-ignore
+  return useQuery({ queryKey: ['language', lang], queryFn: loadLanguage })
+}
+
+export default function Loader({ lang }) {
+  const queryClient = useQueryClient()
+  // @ts-ignore
+  queryClient.prefetchQuery({
+    queryKey: ['language', lang],
+    queryFn: key => {
+      console.log(`triggering queryFn in prefetch:`, key)
+      return loadLanguage(key)
+    },
+  })
+  return <></>
+}

--- a/src/app/(app)/deck/[lang]/page.tsx
+++ b/src/app/(app)/deck/[lang]/page.tsx
@@ -1,0 +1,17 @@
+import languages from 'lib/languages'
+import ClientPage from './client'
+
+export async function generateStaticParams() {
+  return Object.keys(languages).map(lang => ({
+    lang,
+  }))
+}
+
+export default function Page({ params: { lang } }) {
+  return (
+    <>
+      <p>hello {lang}</p>
+      <ClientPage lang={lang} />
+    </>
+  )
+}

--- a/src/app/(app)/login-challenge.jsx
+++ b/src/app/(app)/login-challenge.jsx
@@ -5,8 +5,6 @@ import Modal from 'react-modal'
 import { useAuth } from 'lib/auth-context'
 import LoginForm from 'app/(auth)/login/form'
 
-Modal.setAppElement('#modal-root')
-
 export default function LoginChallenge() {
   const { isAuth } = useAuth()
   const [isDismissed, setIsDismissed] = useState()

--- a/src/lib/helpers.js
+++ b/src/lib/helpers.js
@@ -1,17 +1,18 @@
 export const prependAndDedupe = (item, items) =>
   [item].concat(items?.filter(i => i !== item))
 
-export const convertNodeListToCheckedValues = list => {
-  let x = []
-  list.forEach(el => {
-    if (el.checked) x.push(el.value)
-  })
-  return x
-}
-
 export const BASE_URL =
   process.env.NEXT_PUBLIC_VERCEL_ENV === 'development'
     ? 'http://localhost:3000'
     : process.env.NEXT_PUBLIC_VERCEL_ENV === 'preview'
       ? `https://${process.env.NEXT_PUBLIC_VERCEL_URL}`
       : 'https://sunlo.app'
+
+export default function groupBy(array, key) {
+  let result = {}
+  array.forEach(item => {
+    result[item[key]] ??= []
+    result[item[key]].push(item)
+  })
+  return result
+}

--- a/src/types/client-types.ts
+++ b/src/types/client-types.ts
@@ -1,5 +1,11 @@
 import { Scalars } from './utils'
 
+export type Auth = {
+  isAuth: boolean
+  userEmail?: string
+  userId?: Scalars['UUID']
+}
+
 export type Translation = {
   id: Scalars['UUID']
   lang: string


### PR DESCRIPTION
We want to hoist our data fetching to higher up in the routes tree, fetch it all and stash it all in the necessary query-key slots all at the beginning.

This might involve caching the Languages on the server and fetching only user data on the client, and hydrating the client. Or something like this. There are many options.