### PR TITLE
Remove uses of UseQueryResult().status

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "dev": "next dev --turbo",
     "build": "next build",
-    "start": "next start",
+    "start": "npx serve@latest out",
     "tauri": "tauri",
     "lint": "next lint",
     "format": "prettier --write .",

--- a/src/app/(app)/home/[lang]/client.jsx
+++ b/src/app/(app)/home/[lang]/client.jsx
@@ -30,6 +30,7 @@ const RecentReviewsSummary = ({ lang }) => {
 }
 
 const CardsSummary = ({ deck }) => {
+  if (!deck) return <Loading />
   const { cards_active, cards_learned } = deck
   const cardsInDeck = cards_active + cards_learned
   const beHappy = cards_learned > 5

--- a/src/app/(app)/my-decks/[lang]/browse.jsx
+++ b/src/app/(app)/my-decks/[lang]/browse.jsx
@@ -11,12 +11,11 @@ import BigPhrase from 'components/big-phrase'
 export default function Browse({ lang, disable }) {
   const [activePhraseId, setActivePhraseId] = useState()
 
-  const { data, error, status } = useLanguageDetails(lang)
+  const { data, error, isLoading } = useLanguageDetails(lang)
+  if (isLoading) return <Loading />
+  if (error) return <ErrorList error={error} />
 
-  if (status === 'loading') return <Loading />
-  if (status === 'error') return <ErrorList error={error} />
-  // console.log(`Browse useLanguageDetails, `, data, error)
-  if (!data?.phrases?.length) {
+  if (!data.phrases?.length) {
     return (
       <p className="rounded-lg bg-primary/10 p-6">
         There are no phrases for this language 💩{' '}

--- a/src/app/(app)/my-decks/[lang]/new-card/form.jsx
+++ b/src/app/(app)/my-decks/[lang]/new-card/form.jsx
@@ -15,8 +15,8 @@ import { useProfile } from 'app/data/hooks'
 import { useRouter } from 'next/navigation'
 
 export const SelectLanguageYouKnow = ({ onChange, disabledLang }) => {
-  const { data, status } = useProfile()
-  if (status === 'loading') return <Loading />
+  const { data, isLoading } = useProfile()
+  if (isLoading) return <Loading />
   const { languagesSpoken } = data
   const selectOptions = !languagesSpoken?.length
     ? allLanguageOptions
@@ -58,7 +58,7 @@ export const SelectLanguageYouKnow = ({ onChange, disabledLang }) => {
 }
 
 export default function AddCardPhraseForm({ lang, cancel }) {
-  const { status, data: deck } = useDeck(lang)
+  const { isLoading, data: deck } = useDeck(lang)
   const [selectLang, setSelectLang] = useState()
   const queryClient = useQueryClient()
   const router = useRouter()
@@ -163,7 +163,7 @@ export default function AddCardPhraseForm({ lang, cancel }) {
             <button
               type="submit"
               className="btn btn-primary"
-              disabled={!status === 'success'}
+              disabled={isLoading}
             >
               Submit
             </button>

--- a/src/app/(app)/my-decks/[lang]/phrase/[id]/client.jsx
+++ b/src/app/(app)/my-decks/[lang]/phrase/[id]/client.jsx
@@ -5,40 +5,44 @@ import EditCardStatusButtons from 'components/edit-status-buttons'
 import SectionTranslations from 'components/translations-section'
 import TinyPhrase from 'components/tiny-phrase'
 import { usePhrase } from 'app/data/hooks'
+import Loading from 'components/loading'
+import Error from 'components/error'
 
 export default function Client({ pid }) {
-  const {
-    data: phrase,
-    error: phraseError,
-    status: phraseStatus,
-  } = usePhrase(pid)
+  const { data: phrase, error, isLoading } = usePhrase(pid)
 
-  return (
-    phrase && (
-      <main className="card-white">
-        <h2 lang={phrase.lang} className="h3 font-bold">
-          <TinyPhrase lang={phrase.lang} text={phrase.text} />
-        </h2>
-        <SectionTranslations
-          translations={phrase?.translations}
-          lang={phrase.lang}
-          phraseId={pid}
-          phraseText={phrase.text}
-        />
-        <SectionSeeAlsos
-          seeAlsos={phrase?.see_also_phrases}
-          linkFactory={(lang, pid) => `/my-decks/${lang}/phrase/${pid}`}
-        />
-        {phrase?.card ? (
-          <EditCardStatusButtons cardId={phrase?.card?.id} />
-        ) : (
-          <AddCardButtonsSection
-            phrase_id={pid}
-            user_deck_id={phrase?.card?.user_deck_id}
-            onClose={() => {}}
+  return isLoading ? (
+    <Loading />
+  ) : (
+    <main className="card-white">
+      {error ? (
+        <Error>{error.message}</Error>
+      ) : (
+        <>
+          <h2 lang={phrase.lang} className="h3 font-bold">
+            <TinyPhrase lang={phrase.lang} text={phrase.text} />
+          </h2>
+          <SectionTranslations
+            translations={phrase?.translations}
+            lang={phrase.lang}
+            phraseId={pid}
+            phraseText={phrase.text}
           />
-        )}
-      </main>
-    )
+          <SectionSeeAlsos
+            seeAlsos={phrase?.see_also_phrases}
+            linkFactory={(lang, pid) => `/my-decks/${lang}/phrase/${pid}`}
+          />
+          {phrase?.card ? (
+            <EditCardStatusButtons cardId={phrase?.card?.id} />
+          ) : (
+            <AddCardButtonsSection
+              phrase_id={pid}
+              user_deck_id={phrase?.card?.user_deck_id}
+              onClose={() => {}}
+            />
+          )}
+        </>
+      )}
+    </main>
   )
 }

--- a/src/app/(app)/my-decks/client-page.jsx
+++ b/src/app/(app)/my-decks/client-page.jsx
@@ -22,9 +22,9 @@ function OneDeck({ deck }) {
 }
 
 export default function ClientPage() {
-  const { status, data, error } = useProfile()
-  if (status === 'loading') return <Loading />
-  if (status === 'error') return <ErrorList error={error} />
+  const { isLoading, data, error } = useProfile()
+  if (isLoading) return <Loading />
+  if (error) return <ErrorList error={error} />
 
   const decks = data.deck_stubs
   return (

--- a/src/app/(app)/my-decks/new/form.jsx
+++ b/src/app/(app)/my-decks/new/form.jsx
@@ -34,7 +34,7 @@ export default function Form() {
     },
   })
 
-  const { data, error, status } = useProfile()
+  const { data, error, isLoading } = useProfile()
   const decks = data?.deck_stubs
 
   return (
@@ -42,7 +42,7 @@ export default function Form() {
       {createNewDeck?.error ? (
         <ErrorList summary={`${createNewDeck.error}`} />
       ) : (
-        status === 'error' && <ErrorList summary={`${error.message}`} />
+        error && <ErrorList summary={`${error.message}`} />
       )}
       <form name="new-deck" onSubmit={createNewDeck.mutate}>
         <h2 className="h3">What language would you like to learn?</h2>
@@ -50,7 +50,7 @@ export default function Form() {
           options={allLanguageOptions}
           isOptionDisabled={option =>
             decks?.some(deck => {
-              return status === 'loading'
+              return isLoading
                 ? // while loading the list of decks, all options enabled
                   false
                 : // otherwise, disable languages we're already learning

--- a/src/app/(app)/review/[lang]/card.jsx
+++ b/src/app/(app)/review/[lang]/card.jsx
@@ -35,7 +35,7 @@ export default function CardInner({ card, nextCard, addReview, hidden }) {
     setIsRevealed(true)
   }
 
-  const { data, error, mutate, status } = useMutation({
+  const { data, error, mutate, isPending } = useMutation({
     mutationFn: submission =>
       postReview({ ...submission, card_id: card.id, prevId: data?.id }),
     onSuccess: result => {
@@ -59,7 +59,7 @@ export default function CardInner({ card, nextCard, addReview, hidden }) {
     <div className="card-white">
       <div className="flex flex-col justify-center gap-8 text-center">
         <h2 className="h2 text-center">{card?.phrase?.text}</h2>
-        {isLoading ? (
+        {isPending ? (
           <div className="absolute bottom-0 left-0 right-0 top-0 content-center bg-base-100/70">
             <Loading />
           </div>

--- a/src/app/(app)/review/[lang]/card.jsx
+++ b/src/app/(app)/review/[lang]/card.jsx
@@ -59,12 +59,12 @@ export default function CardInner({ card, nextCard, addReview, hidden }) {
     <div className="card-white">
       <div className="flex flex-col justify-center gap-8 text-center">
         <h2 className="h2 text-center">{card?.phrase?.text}</h2>
-        {status === 'loading' ? (
+        {isLoading ? (
           <div className="absolute bottom-0 left-0 right-0 top-0 content-center bg-base-100/70">
             <Loading />
           </div>
         ) : null}
-        {status === 'error' ? (
+        {error ? (
           <div className="absolute bottom-0 left-0 right-0 top-0 bg-base-100/50">
             <ErrorList error={error} />
           </div>

--- a/src/app/(app)/review/[lang]/client.jsx
+++ b/src/app/(app)/review/[lang]/client.jsx
@@ -27,12 +27,12 @@ const Empty = () => (
 )
 
 export default function ClientPage({ lang }) {
-  const { data, status } = useDeck(lang)
+  const { data, isLoading } = useDeck(lang)
   const reviewCards = useMemo(() => shuffle(data?.cards?.active), [data])
   const [cardIndex, setCardIndex] = useState(0)
   const [reviews, setReviews] = useState([])
 
-  if (status === 'loading') return <Loading />
+  if (isLoading) return <Loading />
   if (!data?.cards?.active?.length > 0) return <Empty />
 
   const canBackup = cardIndex > 0

--- a/src/app/(auth)/forgot-password/form.jsx
+++ b/src/app/(auth)/forgot-password/form.jsx
@@ -75,7 +75,7 @@ export default function ForgotPasswordForm() {
               </div>
             </fieldset>
           </form>
-          {useRequestPasswordForm.status === 'error' ? (
+          {useRequestPasswordForm.error ? (
             <ErrorList
               summary="Error sending password reset"
               error={`${useRequestPasswordForm.error?.message}`}

--- a/src/components/big-phrase.jsx
+++ b/src/components/big-phrase.jsx
@@ -93,21 +93,17 @@ export default function BigPhrase({
   onNavigate,
   noBox,
 }) {
-  const {
-    data: phrase,
-    status: phraseStatus,
-    error: phraseError,
-  } = usePhrase(phrase_id) // || initialData.id
+  const { data: phrase, isLoading, error: phraseError } = usePhrase(phrase_id) // || initialData.id
 
-  if (!phrase_id) return <p>no phrase info provided</p>
-  if (phraseStatus === 'loading') return <Loading />
+  if (!phrase_id) throw 'no phrase info provided'
+  if (isLoading) return <Loading />
 
   const translations = phrase?.translations
   const card = phrase?.card
   // console.log(`bigPhrase look for userCard or phrase.card`, phrase)
   const seeAlsos = phrase?.see_also_phrases
 
-  if (phraseStatus === 'error') return <ErrorList error={phraseError} />
+  if (error) return <ErrorList error={phraseError} />
 
   return (
     <div

--- a/src/components/sidebar.jsx
+++ b/src/components/sidebar.jsx
@@ -71,8 +71,8 @@ const GenericMenu = ({ menu }) => {
 const StaticMenu = () => <GenericMenu menu={staticMenu} />
 
 const DeckMenu = () => {
-  const { data, status, error } = useProfile()
-  if (status === 'loading') return null
+  const { data, isLoading, error } = useProfile()
+  if (isLoading) return null
   if (error) return <ErrorList error={error.message} />
 
   const decks = data?.deck_stubs


### PR DESCRIPTION
I found that it was creating some flash of uninitialized data where status was no longer 'loading' but the data wasn't yet present. That was solved by switching from `status === 'loading'` to `isLoading`. And anyway it's more correct to detect errors by detecting whether the `error` object is populated than with status.

```jsx
// ✅ loading state
if (isLoading) <Loading />
// ❌ not like this
if (status === 'loading') <Loading />

// ✅ error state
if (error) <Error>{error.message}</Error>
// ❌ not like this
if (status === 'error') <Error>{error.message}</Error>
```